### PR TITLE
feat: review 게시글 api 구현

### DIFF
--- a/src/main/java/com/trendist/post_service/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/trendist/post_service/domain/review/controller/ReviewController.java
@@ -1,0 +1,91 @@
+package com.trendist.post_service.domain.review.controller;
+
+import java.util.UUID;
+
+import org.springframework.data.domain.Page;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.trendist.post_service.domain.review.dto.request.ReviewCreateRequest;
+import com.trendist.post_service.domain.review.dto.request.ReviewUpdateRequest;
+import com.trendist.post_service.domain.review.dto.response.ReviewCreateResponse;
+import com.trendist.post_service.domain.review.dto.response.ReviewDeleteResponse;
+import com.trendist.post_service.domain.review.dto.response.ReviewGetAllResponse;
+import com.trendist.post_service.domain.review.dto.response.ReviewGetMineResponse;
+import com.trendist.post_service.domain.review.dto.response.ReviewGetResponse;
+import com.trendist.post_service.domain.review.dto.response.ReviewUpdateResponse;
+import com.trendist.post_service.domain.review.service.ReviewService;
+import com.trendist.post_service.global.response.ApiResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/reviews")
+public class ReviewController {
+	private final ReviewService reviewService;
+
+	@Operation(
+		summary = "리뷰 게시판 게시물 생성",
+		description = "사용자가 리뷰 게시판에 게시불을 생성합니다."
+	)
+	@PostMapping
+	public ApiResponse<ReviewCreateResponse> createReview(@RequestBody ReviewCreateRequest reviewCreateRequest) {
+		return ApiResponse.onSuccess(reviewService.createReview(reviewCreateRequest));
+	}
+
+	@Operation(
+		summary = "리뷰 게시판 게시물 수정",
+		description = "사용자가 리뷰 게시판에 게시물을 수정합니다."
+	)
+	@PatchMapping("/update/{reviewId}")
+	public ApiResponse<ReviewUpdateResponse> updateReview(
+		@PathVariable(name = "reviewId") UUID reviewId,
+		@RequestBody ReviewUpdateRequest reviewUpdateRequest) {
+		return ApiResponse.onSuccess(reviewService.updateReview(reviewId, reviewUpdateRequest));
+	}
+
+	@Operation(
+		summary = "리뷰 게시판 게시물 삭제",
+		description = "사용자가 리뷰 게시판에 게시물을 삭제합니다."
+	)
+	@PatchMapping("/delete/{reviewId}")
+	public ApiResponse<ReviewDeleteResponse> deleteReview(@PathVariable(name = "reviewId") UUID reviewId) {
+		return ApiResponse.onSuccess(reviewService.deleteReview(reviewId));
+	}
+
+	@Operation(
+		summary = "리뷰 게시판 전체 게시물 조회",
+		description = "리뷰 게시판에 전체 게시물을 조회합니다."
+	)
+	@GetMapping
+	public ApiResponse<Page<ReviewGetAllResponse>> getAllReviews(@RequestParam(defaultValue = "0") int page) {
+		return ApiResponse.onSuccess(reviewService.getAllReviews(page));
+	}
+
+	@Operation(
+		summary = "리뷰 게시판 특정 게시물 조회",
+		description = "사용자가 리뷰 게시판에 있는 특정 게시물을 상세 조회합니다."
+	)
+	@GetMapping("/{reviewId}")
+	public ApiResponse<ReviewGetResponse> getReview(@PathVariable(name = "reviewId") UUID reviewId) {
+		return ApiResponse.onSuccess(reviewService.getReview(reviewId));
+	}
+
+	@Operation(
+		summary = "내가 쓴 리뷰 게시판 게시물 조회",
+		description = "현재 로그인한 사용자가 리뷰 게시판에 자신이 생성한 게시물들을 조회합니다."
+	)
+	@GetMapping("/mine")
+	public ApiResponse<Page<ReviewGetMineResponse>> getMyReviews(@RequestParam(defaultValue = "0") int page) {
+		return ApiResponse.onSuccess(reviewService.getMyReviews(page));
+	}
+
+}

--- a/src/main/java/com/trendist/post_service/domain/review/domain/ActivityPeriod.java
+++ b/src/main/java/com/trendist/post_service/domain/review/domain/ActivityPeriod.java
@@ -1,0 +1,9 @@
+package com.trendist.post_service.domain.review.domain;
+
+public enum ActivityPeriod {
+	OneDay,
+	OneWeek,
+	OneMonth,
+	WithinSixMonths,
+	OverSixMonths
+}

--- a/src/main/java/com/trendist/post_service/domain/review/domain/ActivityType.java
+++ b/src/main/java/com/trendist/post_service/domain/review/domain/ActivityType.java
@@ -1,0 +1,8 @@
+package com.trendist.post_service.domain.review.domain;
+
+public enum ActivityType {
+	CONTEST, //공모전
+	VOLUNTEER, //봉사
+	INTERNSHIP, //인턴십
+	SUPPORTERS //서포터즈
+}

--- a/src/main/java/com/trendist/post_service/domain/review/domain/Keyword.java
+++ b/src/main/java/com/trendist/post_service/domain/review/domain/Keyword.java
@@ -1,0 +1,8 @@
+package com.trendist.post_service.domain.review.domain;
+
+public enum Keyword {
+	Environment,
+	PeopleAndSociety,
+	Economy,
+	Technology
+}

--- a/src/main/java/com/trendist/post_service/domain/review/domain/Review.java
+++ b/src/main/java/com/trendist/post_service/domain/review/domain/Review.java
@@ -9,6 +9,8 @@ import jakarta.persistence.CollectionTable;
 import jakarta.persistence.Column;
 import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -40,6 +42,17 @@ public class Review extends BaseTimeEntity {
 
 	@Column(name = "review_title")
 	private String title;
+
+	//review 작성 시 keyword 1개 선택
+	@Enumerated(EnumType.STRING)
+	@Column(name="review_keyword")
+	private Keyword keyword;
+
+	//review 작성 시 ActivityType 1개 선택
+	@Enumerated(EnumType.STRING)
+	@Column(name="review_activity_type")
+	private ActivityType activityType;
+
 
 	@Column(name = "review_content")
 	private String content;

--- a/src/main/java/com/trendist/post_service/domain/review/domain/Review.java
+++ b/src/main/java/com/trendist/post_service/domain/review/domain/Review.java
@@ -1,5 +1,6 @@
 package com.trendist.post_service.domain.review.domain;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 
@@ -45,14 +46,26 @@ public class Review extends BaseTimeEntity {
 
 	//review 작성 시 keyword 1개 선택
 	@Enumerated(EnumType.STRING)
-	@Column(name="review_keyword")
+	@Column(name = "review_keyword")
 	private Keyword keyword;
 
 	//review 작성 시 ActivityType 1개 선택
 	@Enumerated(EnumType.STRING)
-	@Column(name="review_activity_type")
+	@Column(name = "review_activity_type")
 	private ActivityType activityType;
 
+	//review 작성 시 활동 기간 1개 선택
+	@Enumerated(EnumType.STRING)
+	@Column(name = "activity_period")
+	private ActivityPeriod activityPeriod;
+
+	//review 작성 시 활종 종료일 선택
+	@Column(name = "activity_end_date")
+	private LocalDate activityEndDate;
+
+	//review 작성 참여 활동 이름 입력받음
+	@Column(name = "activity_name")
+	private String activityName;
 
 	@Column(name = "review_content")
 	private String content;

--- a/src/main/java/com/trendist/post_service/domain/review/domain/Review.java
+++ b/src/main/java/com/trendist/post_service/domain/review/domain/Review.java
@@ -1,0 +1,55 @@
+package com.trendist.post_service.domain.review.domain;
+
+import java.util.List;
+import java.util.UUID;
+
+import com.trendist.post_service.global.common.domain.BaseTimeEntity;
+
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity(name = "reviews")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Review extends BaseTimeEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.UUID)
+	@Column(name = "review_id")
+	private UUID id;
+
+	@Column(name = "user_id", nullable = false)
+	private UUID userId;
+
+	@Column(name = "nickname")
+	private String nickname;
+
+	@Column(name = "review_title")
+	private String title;
+
+	@Column(name = "review_content")
+	private String content;
+
+	@ElementCollection(fetch = FetchType.EAGER)
+	@CollectionTable(name = "review_image_urls", joinColumns = @JoinColumn(name = "review_id"))
+	@Column(name = "image_urls")
+	private List<String> imageUrls;
+
+	@Column(name = "deleted")
+	@Builder.Default
+	private Boolean deleted = false;
+}

--- a/src/main/java/com/trendist/post_service/domain/review/dto/request/ReviewCreateRequest.java
+++ b/src/main/java/com/trendist/post_service/domain/review/dto/request/ReviewCreateRequest.java
@@ -2,11 +2,16 @@ package com.trendist.post_service.domain.review.dto.request;
 
 import java.util.List;
 
+import com.trendist.post_service.domain.review.domain.ActivityType;
+import com.trendist.post_service.domain.review.domain.Keyword;
+
 import lombok.Builder;
 
 @Builder
 public record ReviewCreateRequest(
 	String title,
+	Keyword keyword,
+	ActivityType activityType,
 	String content,
 	List<String> imageUrls
 ) {

--- a/src/main/java/com/trendist/post_service/domain/review/dto/request/ReviewCreateRequest.java
+++ b/src/main/java/com/trendist/post_service/domain/review/dto/request/ReviewCreateRequest.java
@@ -1,0 +1,13 @@
+package com.trendist.post_service.domain.review.dto.request;
+
+import java.util.List;
+
+import lombok.Builder;
+
+@Builder
+public record ReviewCreateRequest(
+	String title,
+	String content,
+	List<String> imageUrls
+) {
+}

--- a/src/main/java/com/trendist/post_service/domain/review/dto/request/ReviewCreateRequest.java
+++ b/src/main/java/com/trendist/post_service/domain/review/dto/request/ReviewCreateRequest.java
@@ -1,7 +1,9 @@
 package com.trendist.post_service.domain.review.dto.request;
 
+import java.time.LocalDate;
 import java.util.List;
 
+import com.trendist.post_service.domain.review.domain.ActivityPeriod;
 import com.trendist.post_service.domain.review.domain.ActivityType;
 import com.trendist.post_service.domain.review.domain.Keyword;
 
@@ -12,6 +14,9 @@ public record ReviewCreateRequest(
 	String title,
 	Keyword keyword,
 	ActivityType activityType,
+	ActivityPeriod activityPeriod,
+	LocalDate activityEndDate,
+	String activityName,
 	String content,
 	List<String> imageUrls
 ) {

--- a/src/main/java/com/trendist/post_service/domain/review/dto/request/ReviewUpdateRequest.java
+++ b/src/main/java/com/trendist/post_service/domain/review/dto/request/ReviewUpdateRequest.java
@@ -1,0 +1,10 @@
+package com.trendist.post_service.domain.review.dto.request;
+
+import java.util.List;
+
+public record ReviewUpdateRequest(
+	String title,
+	String content,
+	List<String> imageUrls
+) {
+}

--- a/src/main/java/com/trendist/post_service/domain/review/dto/request/ReviewUpdateRequest.java
+++ b/src/main/java/com/trendist/post_service/domain/review/dto/request/ReviewUpdateRequest.java
@@ -1,7 +1,9 @@
 package com.trendist.post_service.domain.review.dto.request;
 
+import java.time.LocalDate;
 import java.util.List;
 
+import com.trendist.post_service.domain.review.domain.ActivityPeriod;
 import com.trendist.post_service.domain.review.domain.ActivityType;
 import com.trendist.post_service.domain.review.domain.Keyword;
 
@@ -9,6 +11,9 @@ public record ReviewUpdateRequest(
 	String title,
 	Keyword keyword,
 	ActivityType activityType,
+	ActivityPeriod activityPeriod,
+	LocalDate activityEndDate,
+	String activityName,
 	String content,
 	List<String> imageUrls
 ) {

--- a/src/main/java/com/trendist/post_service/domain/review/dto/request/ReviewUpdateRequest.java
+++ b/src/main/java/com/trendist/post_service/domain/review/dto/request/ReviewUpdateRequest.java
@@ -2,8 +2,13 @@ package com.trendist.post_service.domain.review.dto.request;
 
 import java.util.List;
 
+import com.trendist.post_service.domain.review.domain.ActivityType;
+import com.trendist.post_service.domain.review.domain.Keyword;
+
 public record ReviewUpdateRequest(
 	String title,
+	Keyword keyword,
+	ActivityType activityType,
 	String content,
 	List<String> imageUrls
 ) {

--- a/src/main/java/com/trendist/post_service/domain/review/dto/response/ReviewCreateResponse.java
+++ b/src/main/java/com/trendist/post_service/domain/review/dto/response/ReviewCreateResponse.java
@@ -3,6 +3,8 @@ package com.trendist.post_service.domain.review.dto.response;
 import java.util.List;
 import java.util.UUID;
 
+import com.trendist.post_service.domain.review.domain.ActivityType;
+import com.trendist.post_service.domain.review.domain.Keyword;
 import com.trendist.post_service.domain.review.domain.Review;
 
 import lombok.Builder;
@@ -13,6 +15,8 @@ public record ReviewCreateResponse(
 	String title,
 	UUID userId,
 	String nickname,
+	Keyword keyword,
+	ActivityType activityType,
 	String content,
 	List<String> imageUrls,
 	Boolean deleted
@@ -23,6 +27,8 @@ public record ReviewCreateResponse(
 			.title(review.getTitle())
 			.userId(review.getUserId())
 			.nickname(review.getNickname())
+			.keyword(review.getKeyword())
+			.activityType(review.getActivityType())
 			.content(review.getContent())
 			.imageUrls(review.getImageUrls())
 			.deleted(review.getDeleted())

--- a/src/main/java/com/trendist/post_service/domain/review/dto/response/ReviewCreateResponse.java
+++ b/src/main/java/com/trendist/post_service/domain/review/dto/response/ReviewCreateResponse.java
@@ -1,0 +1,31 @@
+package com.trendist.post_service.domain.review.dto.response;
+
+import java.util.List;
+import java.util.UUID;
+
+import com.trendist.post_service.domain.review.domain.Review;
+
+import lombok.Builder;
+
+@Builder
+public record ReviewCreateResponse(
+	UUID id,
+	String title,
+	UUID userId,
+	String nickname,
+	String content,
+	List<String> imageUrls,
+	Boolean deleted
+) {
+	public static ReviewCreateResponse from(Review review) {
+		return ReviewCreateResponse.builder()
+			.id(review.getId())
+			.title(review.getTitle())
+			.userId(review.getUserId())
+			.nickname(review.getNickname())
+			.content(review.getContent())
+			.imageUrls(review.getImageUrls())
+			.deleted(review.getDeleted())
+			.build();
+	}
+}

--- a/src/main/java/com/trendist/post_service/domain/review/dto/response/ReviewCreateResponse.java
+++ b/src/main/java/com/trendist/post_service/domain/review/dto/response/ReviewCreateResponse.java
@@ -1,8 +1,10 @@
 package com.trendist.post_service.domain.review.dto.response;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 
+import com.trendist.post_service.domain.review.domain.ActivityPeriod;
 import com.trendist.post_service.domain.review.domain.ActivityType;
 import com.trendist.post_service.domain.review.domain.Keyword;
 import com.trendist.post_service.domain.review.domain.Review;
@@ -17,6 +19,9 @@ public record ReviewCreateResponse(
 	String nickname,
 	Keyword keyword,
 	ActivityType activityType,
+	ActivityPeriod activityPeriod,
+	LocalDate activityEndDate,
+	String activityName,
 	String content,
 	List<String> imageUrls,
 	Boolean deleted
@@ -29,6 +34,9 @@ public record ReviewCreateResponse(
 			.nickname(review.getNickname())
 			.keyword(review.getKeyword())
 			.activityType(review.getActivityType())
+			.activityPeriod(review.getActivityPeriod())
+			.activityEndDate(review.getActivityEndDate())
+			.activityName(review.getActivityName())
 			.content(review.getContent())
 			.imageUrls(review.getImageUrls())
 			.deleted(review.getDeleted())

--- a/src/main/java/com/trendist/post_service/domain/review/dto/response/ReviewDeleteResponse.java
+++ b/src/main/java/com/trendist/post_service/domain/review/dto/response/ReviewDeleteResponse.java
@@ -1,0 +1,22 @@
+package com.trendist.post_service.domain.review.dto.response;
+
+import java.util.UUID;
+
+import com.trendist.post_service.domain.review.domain.Review;
+
+import lombok.Builder;
+
+@Builder
+public record ReviewDeleteResponse(
+	UUID id,
+	String title,
+	Boolean deleted
+) {
+	public static ReviewDeleteResponse from(Review review) {
+		return ReviewDeleteResponse.builder()
+			.id(review.getId())
+			.title(review.getTitle())
+			.deleted(review.getDeleted())
+			.build();
+	}
+}

--- a/src/main/java/com/trendist/post_service/domain/review/dto/response/ReviewGetAllResponse.java
+++ b/src/main/java/com/trendist/post_service/domain/review/dto/response/ReviewGetAllResponse.java
@@ -1,0 +1,26 @@
+package com.trendist.post_service.domain.review.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import com.trendist.post_service.domain.review.domain.Review;
+
+import lombok.Builder;
+
+@Builder
+public record ReviewGetAllResponse(
+	UUID id,
+	String title,
+	String nickname,
+	LocalDateTime createAt
+	//좋아요 수 추가예정
+) {
+	public static ReviewGetAllResponse from(Review review) {
+		return ReviewGetAllResponse.builder()
+			.id(review.getId())
+			.title(review.getTitle())
+			.nickname(review.getNickname())
+			.createAt(review.getCreatedAt())
+			.build();
+	}
+}

--- a/src/main/java/com/trendist/post_service/domain/review/dto/response/ReviewGetMineResponse.java
+++ b/src/main/java/com/trendist/post_service/domain/review/dto/response/ReviewGetMineResponse.java
@@ -1,0 +1,23 @@
+package com.trendist.post_service.domain.review.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import com.trendist.post_service.domain.review.domain.Review;
+
+import lombok.Builder;
+
+@Builder
+public record ReviewGetMineResponse(
+	UUID id,
+	String title,
+	LocalDateTime updatedAt
+) {
+	public static ReviewGetMineResponse from(Review review) {
+		return ReviewGetMineResponse.builder()
+			.id(review.getId())
+			.title(review.getTitle())
+			.updatedAt(review.getUpdatedAt())
+			.build();
+	}
+}

--- a/src/main/java/com/trendist/post_service/domain/review/dto/response/ReviewGetResponse.java
+++ b/src/main/java/com/trendist/post_service/domain/review/dto/response/ReviewGetResponse.java
@@ -3,6 +3,8 @@ package com.trendist.post_service.domain.review.dto.response;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
+import com.trendist.post_service.domain.review.domain.ActivityType;
+import com.trendist.post_service.domain.review.domain.Keyword;
 import com.trendist.post_service.domain.review.domain.Review;
 
 import lombok.Builder;
@@ -11,6 +13,8 @@ import lombok.Builder;
 public record ReviewGetResponse(
 	UUID id,
 	String title,
+	Keyword keyword,
+	ActivityType activityType,
 	String content,
 	UUID userId,
 	String nickname,
@@ -21,6 +25,8 @@ public record ReviewGetResponse(
 		return ReviewGetResponse.builder()
 			.id(review.getId())
 			.title(review.getTitle())
+			.keyword(review.getKeyword())
+			.activityType(review.getActivityType())
 			.content(review.getContent())
 			.userId(review.getUserId())
 			.nickname(review.getNickname())

--- a/src/main/java/com/trendist/post_service/domain/review/dto/response/ReviewGetResponse.java
+++ b/src/main/java/com/trendist/post_service/domain/review/dto/response/ReviewGetResponse.java
@@ -1,8 +1,10 @@
 package com.trendist.post_service.domain.review.dto.response;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
+import com.trendist.post_service.domain.review.domain.ActivityPeriod;
 import com.trendist.post_service.domain.review.domain.ActivityType;
 import com.trendist.post_service.domain.review.domain.Keyword;
 import com.trendist.post_service.domain.review.domain.Review;
@@ -15,6 +17,9 @@ public record ReviewGetResponse(
 	String title,
 	Keyword keyword,
 	ActivityType activityType,
+	ActivityPeriod activityPeriod,
+	LocalDate activityEndDate,
+	String activityName,
 	String content,
 	UUID userId,
 	String nickname,
@@ -27,6 +32,9 @@ public record ReviewGetResponse(
 			.title(review.getTitle())
 			.keyword(review.getKeyword())
 			.activityType(review.getActivityType())
+			.activityPeriod(review.getActivityPeriod())
+			.activityEndDate(review.getActivityEndDate())
+			.activityName(review.getActivityName())
 			.content(review.getContent())
 			.userId(review.getUserId())
 			.nickname(review.getNickname())

--- a/src/main/java/com/trendist/post_service/domain/review/dto/response/ReviewGetResponse.java
+++ b/src/main/java/com/trendist/post_service/domain/review/dto/response/ReviewGetResponse.java
@@ -1,0 +1,31 @@
+package com.trendist.post_service.domain.review.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import com.trendist.post_service.domain.review.domain.Review;
+
+import lombok.Builder;
+
+@Builder
+public record ReviewGetResponse(
+	UUID id,
+	String title,
+	String content,
+	UUID userId,
+	String nickname,
+	String profileUrl,
+	LocalDateTime createdAt
+) {
+	public static ReviewGetResponse of(Review review, String profileUrl) {
+		return ReviewGetResponse.builder()
+			.id(review.getId())
+			.title(review.getTitle())
+			.content(review.getContent())
+			.userId(review.getUserId())
+			.nickname(review.getNickname())
+			.profileUrl(profileUrl)
+			.createdAt(review.getCreatedAt())
+			.build();
+	}
+}

--- a/src/main/java/com/trendist/post_service/domain/review/dto/response/ReviewUpdateResponse.java
+++ b/src/main/java/com/trendist/post_service/domain/review/dto/response/ReviewUpdateResponse.java
@@ -1,9 +1,11 @@
 package com.trendist.post_service.domain.review.dto.response;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
+import com.trendist.post_service.domain.review.domain.ActivityPeriod;
 import com.trendist.post_service.domain.review.domain.ActivityType;
 import com.trendist.post_service.domain.review.domain.Keyword;
 import com.trendist.post_service.domain.review.domain.Review;
@@ -16,6 +18,9 @@ public record ReviewUpdateResponse(
 	String title,
 	Keyword keyword,
 	ActivityType activityType,
+	ActivityPeriod activityPeriod,
+	LocalDate activityEndDate,
+	String activityName,
 	String content,
 	List<String> imageUrls,
 	LocalDateTime updatedAt
@@ -26,6 +31,9 @@ public record ReviewUpdateResponse(
 			.title(review.getTitle())
 			.keyword(review.getKeyword())
 			.activityType(review.getActivityType())
+			.activityPeriod(review.getActivityPeriod())
+			.activityEndDate(review.getActivityEndDate())
+			.activityName(review.getActivityName())
 			.content(review.getContent())
 			.imageUrls(review.getImageUrls())
 			.updatedAt(review.getUpdatedAt())

--- a/src/main/java/com/trendist/post_service/domain/review/dto/response/ReviewUpdateResponse.java
+++ b/src/main/java/com/trendist/post_service/domain/review/dto/response/ReviewUpdateResponse.java
@@ -4,6 +4,8 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
+import com.trendist.post_service.domain.review.domain.ActivityType;
+import com.trendist.post_service.domain.review.domain.Keyword;
 import com.trendist.post_service.domain.review.domain.Review;
 
 import lombok.Builder;
@@ -12,6 +14,8 @@ import lombok.Builder;
 public record ReviewUpdateResponse(
 	UUID id,
 	String title,
+	Keyword keyword,
+	ActivityType activityType,
 	String content,
 	List<String> imageUrls,
 	LocalDateTime updatedAt
@@ -20,6 +24,8 @@ public record ReviewUpdateResponse(
 		return ReviewUpdateResponse.builder()
 			.id(review.getId())
 			.title(review.getTitle())
+			.keyword(review.getKeyword())
+			.activityType(review.getActivityType())
 			.content(review.getContent())
 			.imageUrls(review.getImageUrls())
 			.updatedAt(review.getUpdatedAt())

--- a/src/main/java/com/trendist/post_service/domain/review/dto/response/ReviewUpdateResponse.java
+++ b/src/main/java/com/trendist/post_service/domain/review/dto/response/ReviewUpdateResponse.java
@@ -1,0 +1,28 @@
+package com.trendist.post_service.domain.review.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import com.trendist.post_service.domain.review.domain.Review;
+
+import lombok.Builder;
+
+@Builder
+public record ReviewUpdateResponse(
+	UUID id,
+	String title,
+	String content,
+	List<String> imageUrls,
+	LocalDateTime updatedAt
+) {
+	public static ReviewUpdateResponse from(Review review) {
+		return ReviewUpdateResponse.builder()
+			.id(review.getId())
+			.title(review.getTitle())
+			.content(review.getContent())
+			.imageUrls(review.getImageUrls())
+			.updatedAt(review.getUpdatedAt())
+			.build();
+	}
+}

--- a/src/main/java/com/trendist/post_service/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/trendist/post_service/domain/review/repository/ReviewRepository.java
@@ -1,0 +1,18 @@
+package com.trendist.post_service.domain.review.repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.trendist.post_service.domain.review.domain.Review;
+
+public interface ReviewRepository extends JpaRepository<Review, UUID> {
+	Page<Review> findAllByDeletedFalse(Pageable pageable);
+
+	Optional<Review> findByIdAndDeletedFalse(UUID id);
+
+	Page<Review> findByUserIdAndDeletedFalse(UUID id, Pageable pageable);
+}

--- a/src/main/java/com/trendist/post_service/domain/review/service/ReviewService.java
+++ b/src/main/java/com/trendist/post_service/domain/review/service/ReviewService.java
@@ -1,0 +1,109 @@
+package com.trendist.post_service.domain.review.service;
+
+import java.util.UUID;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.trendist.post_service.domain.review.domain.Review;
+import com.trendist.post_service.domain.review.dto.request.ReviewCreateRequest;
+import com.trendist.post_service.domain.review.dto.request.ReviewUpdateRequest;
+import com.trendist.post_service.domain.review.dto.response.ReviewCreateResponse;
+import com.trendist.post_service.domain.review.dto.response.ReviewDeleteResponse;
+import com.trendist.post_service.domain.review.dto.response.ReviewGetAllResponse;
+import com.trendist.post_service.domain.review.dto.response.ReviewGetMineResponse;
+import com.trendist.post_service.domain.review.dto.response.ReviewGetResponse;
+import com.trendist.post_service.domain.review.dto.response.ReviewUpdateResponse;
+import com.trendist.post_service.domain.review.repository.ReviewRepository;
+import com.trendist.post_service.global.exception.ApiException;
+import com.trendist.post_service.global.feign.user.client.UserServiceClient;
+import com.trendist.post_service.global.response.status.ErrorStatus;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ReviewService {
+	private final ReviewRepository reviewRepository;
+	private final UserServiceClient userServiceClient;
+
+	@Transactional
+	public ReviewCreateResponse createReview(ReviewCreateRequest reviewCreateRequest) {
+		UUID userId = userServiceClient.getMyProfile("").getResult().id();
+		String nickname = userServiceClient.getMyProfile("").getResult().nickname();
+
+		Review review = Review.builder()
+			.title(reviewCreateRequest.title())
+			.content(reviewCreateRequest.content())
+			.imageUrls(reviewCreateRequest.imageUrls())
+			.userId(userId)
+			.nickname(nickname)
+			.build();
+
+		reviewRepository.save(review);
+
+		return ReviewCreateResponse.from(review);
+	}
+
+	@Transactional
+	public ReviewUpdateResponse updateReview(UUID reviewId, ReviewUpdateRequest reviewUpdateRequest) {
+		Review review = reviewRepository.findByIdAndDeletedFalse(reviewId)
+			.orElseThrow(() -> new ApiException(ErrorStatus._REVIEW_NOT_FOUND));
+
+		UUID nowUserId = userServiceClient.getMyProfile("").getResult().id();
+		if (!nowUserId.equals(review.getUserId())) {
+			throw new ApiException(ErrorStatus._REVIEW_UPDATE_FORBIDDEN);
+		}
+
+		review.setTitle(reviewUpdateRequest.title());
+		review.setContent(reviewUpdateRequest.content());
+		review.setImageUrls(reviewUpdateRequest.imageUrls());
+
+		reviewRepository.save(review);
+
+		return ReviewUpdateResponse.from(review);
+	}
+
+	@Transactional
+	public ReviewDeleteResponse deleteReview(UUID reviewId) {
+		Review review = reviewRepository.findByIdAndDeletedFalse(reviewId)
+			.orElseThrow(() -> new ApiException(ErrorStatus._REVIEW_NOT_FOUND));
+
+		UUID nowUserId = userServiceClient.getMyProfile("").getResult().id();
+		if (!nowUserId.equals(review.getUserId())) {
+			throw new ApiException(ErrorStatus._REVIEW_DELETE_FORBIDDEN);
+		}
+
+		review.setDeleted(true);
+
+		reviewRepository.save(review);
+
+		return ReviewDeleteResponse.from(review);
+	}
+
+	public Page<ReviewGetAllResponse> getAllReviews(int page) {
+		Pageable pageable = PageRequest.of(page, 10, Sort.by("createdAt").descending());
+		return reviewRepository.findAllByDeletedFalse(pageable)
+			.map(ReviewGetAllResponse::from);
+	}
+
+	public ReviewGetResponse getReview(UUID reviewId) {
+		Review review = reviewRepository.findByIdAndDeletedFalse(reviewId)
+			.orElseThrow(() -> new ApiException(ErrorStatus._REVIEW_NOT_FOUND));
+		String profileUrl = userServiceClient.getUserProfile(review.getUserId()).getResult().profileUrl();
+
+		return ReviewGetResponse.of(review, profileUrl);
+	}
+
+	public Page<ReviewGetMineResponse> getMyReviews(int page) {
+		UUID userId = userServiceClient.getMyProfile("").getResult().id();
+		Pageable pageable = PageRequest.of(page, 10, Sort.by("updatedAt").descending());
+
+		return reviewRepository.findByUserIdAndDeletedFalse(userId, pageable)
+			.map(ReviewGetMineResponse::from);
+	}
+}

--- a/src/main/java/com/trendist/post_service/domain/review/service/ReviewService.java
+++ b/src/main/java/com/trendist/post_service/domain/review/service/ReviewService.java
@@ -36,6 +36,11 @@ public class ReviewService {
 		UUID userId = userServiceClient.getMyProfile("").getResult().id();
 		String nickname = userServiceClient.getMyProfile("").getResult().nickname();
 
+		//review 작성 시 이미지 최소 1장 필수
+		if (reviewCreateRequest.imageUrls().isEmpty()) {
+			throw new ApiException(ErrorStatus._REVIEW_IMAGE_REQUIRED);
+		}
+
 		Review review = Review.builder()
 			.title(reviewCreateRequest.title())
 			.keyword(reviewCreateRequest.keyword())
@@ -62,6 +67,11 @@ public class ReviewService {
 		UUID nowUserId = userServiceClient.getMyProfile("").getResult().id();
 		if (!nowUserId.equals(review.getUserId())) {
 			throw new ApiException(ErrorStatus._REVIEW_UPDATE_FORBIDDEN);
+		}
+
+		//review 작성 시 이미지 최소 1장 필수
+		if (reviewUpdateRequest.imageUrls().isEmpty()) {
+			throw new ApiException(ErrorStatus._REVIEW_IMAGE_REQUIRED);
 		}
 
 		review.setTitle(reviewUpdateRequest.title());

--- a/src/main/java/com/trendist/post_service/domain/review/service/ReviewService.java
+++ b/src/main/java/com/trendist/post_service/domain/review/service/ReviewService.java
@@ -37,7 +37,7 @@ public class ReviewService {
 		String nickname = userServiceClient.getMyProfile("").getResult().nickname();
 
 		//review 작성 시 이미지 최소 1장 필수
-		if (reviewCreateRequest.imageUrls().isEmpty()) {
+		if (reviewCreateRequest.imageUrls() == null || reviewCreateRequest.imageUrls().isEmpty()) {
 			throw new ApiException(ErrorStatus._REVIEW_IMAGE_REQUIRED);
 		}
 
@@ -70,7 +70,7 @@ public class ReviewService {
 		}
 
 		//review 작성 시 이미지 최소 1장 필수
-		if (reviewUpdateRequest.imageUrls().isEmpty()) {
+		if (reviewUpdateRequest.imageUrls() == null || reviewUpdateRequest.imageUrls().isEmpty()) {
 			throw new ApiException(ErrorStatus._REVIEW_IMAGE_REQUIRED);
 		}
 

--- a/src/main/java/com/trendist/post_service/domain/review/service/ReviewService.java
+++ b/src/main/java/com/trendist/post_service/domain/review/service/ReviewService.java
@@ -40,6 +40,9 @@ public class ReviewService {
 			.title(reviewCreateRequest.title())
 			.keyword(reviewCreateRequest.keyword())
 			.activityType(reviewCreateRequest.activityType())
+			.activityPeriod(reviewCreateRequest.activityPeriod())
+			.activityEndDate(reviewCreateRequest.activityEndDate())
+			.activityName(reviewCreateRequest.activityName())
 			.content(reviewCreateRequest.content())
 			.imageUrls(reviewCreateRequest.imageUrls())
 			.userId(userId)
@@ -62,6 +65,11 @@ public class ReviewService {
 		}
 
 		review.setTitle(reviewUpdateRequest.title());
+		review.setKeyword(reviewUpdateRequest.keyword());
+		review.setActivityType(reviewUpdateRequest.activityType());
+		review.setActivityPeriod(reviewUpdateRequest.activityPeriod());
+		review.setActivityEndDate(reviewUpdateRequest.activityEndDate());
+		review.setActivityName(reviewUpdateRequest.activityName());
 		review.setContent(reviewUpdateRequest.content());
 		review.setImageUrls(reviewUpdateRequest.imageUrls());
 

--- a/src/main/java/com/trendist/post_service/domain/review/service/ReviewService.java
+++ b/src/main/java/com/trendist/post_service/domain/review/service/ReviewService.java
@@ -38,6 +38,8 @@ public class ReviewService {
 
 		Review review = Review.builder()
 			.title(reviewCreateRequest.title())
+			.keyword(reviewCreateRequest.keyword())
+			.activityType(reviewCreateRequest.activityType())
 			.content(reviewCreateRequest.content())
 			.imageUrls(reviewCreateRequest.imageUrls())
 			.userId(userId)

--- a/src/main/java/com/trendist/post_service/global/response/status/ErrorStatus.java
+++ b/src/main/java/com/trendist/post_service/global/response/status/ErrorStatus.java
@@ -28,6 +28,11 @@ public enum ErrorStatus implements BaseErrorCode {
 	_POST_UPDATE_FORBIDDEN(HttpStatus.FORBIDDEN, "POST_002", "게시물을 수정 요청이 거부되었습니다."),
 	_POST_DELETE_FORBIDDEN(HttpStatus.FORBIDDEN, "POST_003", "게시물을 삭제 요청이 거부되었습니다."),
 
+	_REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "REVIEW_001", "해당 게시물이 존재하지 않습니다."),
+	_REVIEW_UPDATE_FORBIDDEN(HttpStatus.FORBIDDEN, "REVIEW_002", "게시물을 수정 요청이 거부되었습니다."),
+	_REVIEW_DELETE_FORBIDDEN(HttpStatus.FORBIDDEN, "REVIEW_003", "게시물을 삭제 요청이 거부되었습니다."),
+
+
 	//s3 관련
 	_S3_OVER_MAX_FILES(HttpStatus.BAD_REQUEST, "s3_001", "최대 파일 수를 초과하였습니다.");
 

--- a/src/main/java/com/trendist/post_service/global/response/status/ErrorStatus.java
+++ b/src/main/java/com/trendist/post_service/global/response/status/ErrorStatus.java
@@ -32,7 +32,6 @@ public enum ErrorStatus implements BaseErrorCode {
 	_REVIEW_UPDATE_FORBIDDEN(HttpStatus.FORBIDDEN, "REVIEW_002", "게시물을 수정 요청이 거부되었습니다."),
 	_REVIEW_DELETE_FORBIDDEN(HttpStatus.FORBIDDEN, "REVIEW_003", "게시물을 삭제 요청이 거부되었습니다."),
 
-
 	//s3 관련
 	_S3_OVER_MAX_FILES(HttpStatus.BAD_REQUEST, "s3_001", "최대 파일 수를 초과하였습니다.");
 

--- a/src/main/java/com/trendist/post_service/global/response/status/ErrorStatus.java
+++ b/src/main/java/com/trendist/post_service/global/response/status/ErrorStatus.java
@@ -31,6 +31,7 @@ public enum ErrorStatus implements BaseErrorCode {
 	_REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "REVIEW_001", "해당 게시물이 존재하지 않습니다."),
 	_REVIEW_UPDATE_FORBIDDEN(HttpStatus.FORBIDDEN, "REVIEW_002", "게시물을 수정 요청이 거부되었습니다."),
 	_REVIEW_DELETE_FORBIDDEN(HttpStatus.FORBIDDEN, "REVIEW_003", "게시물을 삭제 요청이 거부되었습니다."),
+	_REVIEW_IMAGE_REQUIRED(HttpStatus.BAD_REQUEST, "REVIEW_004", "리뷰에는 최소 1개의 이미지를 첨부해야 합니다."),
 
 	//s3 관련
 	_S3_OVER_MAX_FILES(HttpStatus.BAD_REQUEST, "s3_001", "최대 파일 수를 초과하였습니다.");


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [x] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용
1. review 게시물 작성
- (자유 게시물과는 다르게) review 게시물 생성 시, keyword, activity type을 추가해야 합니다.

![image](https://github.com/user-attachments/assets/fdfe335f-434a-4dd5-878f-92cb0365739f)


2. 전체 review 게시물 조회 api
- 삭제 되지 않은 전체 review 게시물을 조회합니다.

![image](https://github.com/user-attachments/assets/947bb6d6-3db7-4085-ad8e-bf19085c6c98)
![image](https://github.com/user-attachments/assets/b9995bef-003d-479e-bd93-a0f1c01cda17)


3. 특정 review 게시물 조회 api
- id를 사용하여 특정 review 게시물(test2번 review)을 가져오는 모습을 확인 할 수 있습니다.

![image](https://github.com/user-attachments/assets/55d61174-eff4-41d0-b145-4c9537ca257f)


4. review 게시물 삭제 api
- 실제로 게시글이 삭제되는 것이 아닌, deleted field의 값을 true로 적용하여 사용자가 확인할 수 없게 하는 방식입니다.

![image](https://github.com/user-attachments/assets/cb642afb-e308-4d79-b394-0025c4ca02a8)


5. 로그인 한 계정의 게시물 조회 api

![image](https://github.com/user-attachments/assets/c319ff9a-17dd-45da-ab16-5cccff832493)



---

## 🔗 관련 이슈
- close #10 

---

## 💡 추가 사항
create review 시 활동 인증사진1개, keyword 1개, activity 1개를 "필수"로 선택하게 하는 기능 추가 구현이 필요합니다.
