### PR TITLE
feat: 댓글 기능 및 게시물 좋아요 기능 구현

### DIFF
--- a/src/main/java/com/trendist/post_service/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/trendist/post_service/domain/comment/controller/CommentController.java
@@ -1,0 +1,35 @@
+package com.trendist.post_service.domain.comment.controller;
+
+import java.util.UUID;
+
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.trendist.post_service.domain.comment.dto.request.CommentCreateRequest;
+import com.trendist.post_service.domain.comment.dto.response.CommentCreateResponse;
+import com.trendist.post_service.domain.comment.service.CommentService;
+import com.trendist.post_service.global.response.ApiResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("posts/comments")
+public class CommentController {
+	private final CommentService commentService;
+
+	@Operation(
+		summary = "게시물 댓글 작성",
+		description = "특정 게시물에 댓글을 작성합니다."
+	)
+	@PostMapping("/{postId}")
+	public ApiResponse<CommentCreateResponse> createComment(
+		@PathVariable(name = "postId") UUID postId,
+		@RequestBody CommentCreateRequest commentCreateRequest) {
+		return ApiResponse.onSuccess(commentService.createComment(postId, commentCreateRequest));
+	}
+}

--- a/src/main/java/com/trendist/post_service/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/trendist/post_service/domain/comment/controller/CommentController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.trendist.post_service.domain.comment.dto.request.CommentCreateOrUpdateRequest;
 import com.trendist.post_service.domain.comment.dto.response.CommentCreateResponse;
+import com.trendist.post_service.domain.comment.dto.response.CommentDeleteResponse;
 import com.trendist.post_service.domain.comment.dto.response.CommentGetAllResponse;
 import com.trendist.post_service.domain.comment.dto.response.CommentUpdateResponse;
 import com.trendist.post_service.domain.comment.service.CommentService;
@@ -43,12 +44,21 @@ public class CommentController {
 		summary = "댓글 수정",
 		description = "특정 댓글을 수정합니다."
 	)
-	@PatchMapping("/{commentId}")
+	@PatchMapping("/update/{commentId}")
 	public ApiResponse<CommentUpdateResponse> updateComment(
 		@PathVariable(name = "commentId") UUID commentId,
 		@RequestBody CommentCreateOrUpdateRequest commentCreateOrUpdateRequest
 	) {
 		return ApiResponse.onSuccess(commentService.updateComment(commentId, commentCreateOrUpdateRequest));
+	}
+
+	@Operation(
+		summary = "댓글 삭제",
+		description = "특정 댓글을 삭제합니다."
+	)
+	@PatchMapping("/delete/{commentId}")
+	public ApiResponse<CommentDeleteResponse> deleteComment(@PathVariable(name = "commentId") UUID commentId) {
+		return ApiResponse.onSuccess(commentService.deleteComment(commentId));
 	}
 
 	@Operation(

--- a/src/main/java/com/trendist/post_service/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/trendist/post_service/domain/comment/controller/CommentController.java
@@ -4,15 +4,17 @@ import java.util.List;
 import java.util.UUID;
 
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.trendist.post_service.domain.comment.dto.request.CommentCreateRequest;
+import com.trendist.post_service.domain.comment.dto.request.CommentCreateOrUpdateRequest;
 import com.trendist.post_service.domain.comment.dto.response.CommentCreateResponse;
 import com.trendist.post_service.domain.comment.dto.response.CommentGetAllResponse;
+import com.trendist.post_service.domain.comment.dto.response.CommentUpdateResponse;
 import com.trendist.post_service.domain.comment.service.CommentService;
 import com.trendist.post_service.global.response.ApiResponse;
 
@@ -32,8 +34,21 @@ public class CommentController {
 	@PostMapping("/{postId}")
 	public ApiResponse<CommentCreateResponse> createComment(
 		@PathVariable(name = "postId") UUID postId,
-		@RequestBody CommentCreateRequest commentCreateRequest) {
-		return ApiResponse.onSuccess(commentService.createComment(postId, commentCreateRequest));
+		@RequestBody CommentCreateOrUpdateRequest commentCreateOrUpdateRequest
+	) {
+		return ApiResponse.onSuccess(commentService.createComment(postId, commentCreateOrUpdateRequest));
+	}
+
+	@Operation(
+		summary = "댓글 수정",
+		description = "특정 댓글을 수정합니다."
+	)
+	@PatchMapping("/{commentId}")
+	public ApiResponse<CommentUpdateResponse> updateComment(
+		@PathVariable(name = "commentId") UUID commentId,
+		@RequestBody CommentCreateOrUpdateRequest commentCreateOrUpdateRequest
+	) {
+		return ApiResponse.onSuccess(commentService.updateComment(commentId, commentCreateOrUpdateRequest));
 	}
 
 	@Operation(

--- a/src/main/java/com/trendist/post_service/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/trendist/post_service/domain/comment/controller/CommentController.java
@@ -24,20 +24,20 @@ import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("posts/comments")
+@RequestMapping("/comments")
 public class CommentController {
 	private final CommentService commentService;
 
 	@Operation(
 		summary = "게시물 댓글 작성",
-		description = "특정 게시물에 댓글을 작성합니다."
+		description = "특정 게시물 혹은 리뷰 게시물에 댓글을 작성합니다."
 	)
-	@PostMapping("/{postId}")
+	@PostMapping("/{id}")
 	public ApiResponse<CommentCreateResponse> createComment(
-		@PathVariable(name = "postId") UUID postId,
+		@PathVariable(name = "id") UUID id,
 		@RequestBody CommentCreateOrUpdateRequest commentCreateOrUpdateRequest
 	) {
-		return ApiResponse.onSuccess(commentService.createComment(postId, commentCreateOrUpdateRequest));
+		return ApiResponse.onSuccess(commentService.createComment(id, commentCreateOrUpdateRequest));
 	}
 
 	@Operation(
@@ -65,9 +65,9 @@ public class CommentController {
 		summary = "댓글 확인",
 		description = "특정 게시물에 작성된 모든 댓글을 확인합니다."
 	)
-	@GetMapping("/{postId}")
+	@GetMapping("/{id}")
 	public ApiResponse<List<CommentGetAllResponse>> getPostComments(
-		@PathVariable(name = "postId") UUID postId) {
-		return ApiResponse.onSuccess(commentService.getPostComments(postId));
+		@PathVariable(name = "id") UUID id) {
+		return ApiResponse.onSuccess(commentService.getPostComments(id));
 	}
 }

--- a/src/main/java/com/trendist/post_service/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/trendist/post_service/domain/comment/controller/CommentController.java
@@ -1,7 +1,9 @@
 package com.trendist.post_service.domain.comment.controller;
 
+import java.util.List;
 import java.util.UUID;
 
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -10,6 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.trendist.post_service.domain.comment.dto.request.CommentCreateRequest;
 import com.trendist.post_service.domain.comment.dto.response.CommentCreateResponse;
+import com.trendist.post_service.domain.comment.dto.response.CommentGetAllResponse;
 import com.trendist.post_service.domain.comment.service.CommentService;
 import com.trendist.post_service.global.response.ApiResponse;
 
@@ -31,5 +34,15 @@ public class CommentController {
 		@PathVariable(name = "postId") UUID postId,
 		@RequestBody CommentCreateRequest commentCreateRequest) {
 		return ApiResponse.onSuccess(commentService.createComment(postId, commentCreateRequest));
+	}
+
+	@Operation(
+		summary = "댓글 확인",
+		description = "특정 게시물에 작성된 모든 댓글을 확인합니다."
+	)
+	@GetMapping("/{postId}")
+	public ApiResponse<List<CommentGetAllResponse>> getPostComments(
+		@PathVariable(name = "postId") UUID postId) {
+		return ApiResponse.onSuccess(commentService.getPostComments(postId));
 	}
 }

--- a/src/main/java/com/trendist/post_service/domain/comment/domain/Comment.java
+++ b/src/main/java/com/trendist/post_service/domain/comment/domain/Comment.java
@@ -1,0 +1,39 @@
+package com.trendist.post_service.domain.comment.domain;
+
+import java.util.UUID;
+
+import com.trendist.post_service.domain.post.domain.Post;
+import com.trendist.post_service.global.common.domain.BaseTimeEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity(name = "comments")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Comment extends BaseTimeEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.UUID)
+	@Column(name = "comment_id")
+	private UUID id;
+
+	@Column(name = "user_id", nullable = false)
+	private UUID userId;
+
+	@ManyToOne
+	@JoinColumn(name = "post_id")
+	private Post post;
+}

--- a/src/main/java/com/trendist/post_service/domain/comment/domain/Comment.java
+++ b/src/main/java/com/trendist/post_service/domain/comment/domain/Comment.java
@@ -3,6 +3,7 @@ package com.trendist.post_service.domain.comment.domain;
 import java.util.UUID;
 
 import com.trendist.post_service.domain.post.domain.Post;
+import com.trendist.post_service.domain.review.domain.Review;
 import com.trendist.post_service.global.common.domain.BaseTimeEntity;
 
 import jakarta.persistence.Column;
@@ -36,6 +37,10 @@ public class Comment extends BaseTimeEntity {
 	@ManyToOne
 	@JoinColumn(name = "post_id")
 	private Post post;
+
+	@ManyToOne
+	@JoinColumn(name = "review_id")
+	private Review review;
 
 	@Column(name = "content")
 	private String content;

--- a/src/main/java/com/trendist/post_service/domain/comment/domain/Comment.java
+++ b/src/main/java/com/trendist/post_service/domain/comment/domain/Comment.java
@@ -39,4 +39,8 @@ public class Comment extends BaseTimeEntity {
 
 	@Column(name = "content")
 	private String content;
+
+	@Column(name = "deleted")
+	@Builder.Default
+	private Boolean deleted = false;
 }

--- a/src/main/java/com/trendist/post_service/domain/comment/domain/Comment.java
+++ b/src/main/java/com/trendist/post_service/domain/comment/domain/Comment.java
@@ -36,4 +36,7 @@ public class Comment extends BaseTimeEntity {
 	@ManyToOne
 	@JoinColumn(name = "post_id")
 	private Post post;
+
+	@Column(name = "content")
+	private String content;
 }

--- a/src/main/java/com/trendist/post_service/domain/comment/dto/request/CommentCreateOrUpdateRequest.java
+++ b/src/main/java/com/trendist/post_service/domain/comment/dto/request/CommentCreateOrUpdateRequest.java
@@ -1,6 +1,6 @@
 package com.trendist.post_service.domain.comment.dto.request;
 
-public record CommentCreateRequest(
+public record CommentCreateOrUpdateRequest(
 	String content
 ) {
 }

--- a/src/main/java/com/trendist/post_service/domain/comment/dto/request/CommentCreateRequest.java
+++ b/src/main/java/com/trendist/post_service/domain/comment/dto/request/CommentCreateRequest.java
@@ -1,0 +1,6 @@
+package com.trendist.post_service.domain.comment.dto.request;
+
+public record CommentCreateRequest(
+	String content
+) {
+}

--- a/src/main/java/com/trendist/post_service/domain/comment/dto/response/CommentCreateResponse.java
+++ b/src/main/java/com/trendist/post_service/domain/comment/dto/response/CommentCreateResponse.java
@@ -11,14 +11,19 @@ import lombok.Builder;
 public record CommentCreateResponse(
 	UUID commentId,
 	UUID postId,
+	UUID reviewId,
 	UUID userId,
 	String content,
 	LocalDateTime createdAt
 ) {
 	public static CommentCreateResponse from(Comment comment) {
+		UUID postId = comment.getPost() != null ? comment.getPost().getId() : null;
+		UUID reviewId = comment.getReview() != null ? comment.getReview().getId() : null;
+
 		return CommentCreateResponse.builder()
 			.commentId(comment.getId())
-			.postId(comment.getPost().getId())
+			.postId(postId)
+			.reviewId(reviewId)
 			.userId(comment.getUserId())
 			.content(comment.getContent())
 			.createdAt(comment.getCreatedAt())

--- a/src/main/java/com/trendist/post_service/domain/comment/dto/response/CommentCreateResponse.java
+++ b/src/main/java/com/trendist/post_service/domain/comment/dto/response/CommentCreateResponse.java
@@ -1,0 +1,31 @@
+package com.trendist.post_service.domain.comment.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import com.trendist.post_service.domain.comment.domain.Comment;
+
+import lombok.Builder;
+
+@Builder
+public record CommentCreateResponse(
+	UUID commentId,
+	UUID postId,
+	UUID userId,
+	String nickname,
+	String profileUrl,
+	String content,
+	LocalDateTime createdAt
+) {
+	public static CommentCreateResponse of(Comment comment, String nickname, String profileUrl) {
+		return CommentCreateResponse.builder()
+			.commentId(comment.getId())
+			.postId(comment.getPost().getId())
+			.userId(comment.getUserId())
+			.nickname(nickname)
+			.profileUrl(profileUrl)
+			.content(comment.getContent())
+			.createdAt(comment.getCreatedAt())
+			.build();
+	}
+}

--- a/src/main/java/com/trendist/post_service/domain/comment/dto/response/CommentDeleteResponse.java
+++ b/src/main/java/com/trendist/post_service/domain/comment/dto/response/CommentDeleteResponse.java
@@ -1,0 +1,24 @@
+package com.trendist.post_service.domain.comment.dto.response;
+
+import java.util.UUID;
+
+import com.trendist.post_service.domain.comment.domain.Comment;
+
+import lombok.Builder;
+
+@Builder
+public record CommentDeleteResponse(
+	UUID postId,
+	UUID commentId,
+	UUID userId,
+	Boolean deleted
+) {
+	public static CommentDeleteResponse from(Comment comment) {
+		return CommentDeleteResponse.builder()
+			.postId(comment.getPost().getId())
+			.commentId(comment.getId())
+			.userId(comment.getUserId())
+			.deleted(comment.getDeleted())
+			.build();
+	}
+}

--- a/src/main/java/com/trendist/post_service/domain/comment/dto/response/CommentDeleteResponse.java
+++ b/src/main/java/com/trendist/post_service/domain/comment/dto/response/CommentDeleteResponse.java
@@ -8,15 +8,20 @@ import lombok.Builder;
 
 @Builder
 public record CommentDeleteResponse(
-	UUID postId,
 	UUID commentId,
+	UUID postId,
+	UUID reviewId,
 	UUID userId,
 	Boolean deleted
 ) {
 	public static CommentDeleteResponse from(Comment comment) {
+		UUID postId = comment.getPost() != null ? comment.getPost().getId() : null;
+		UUID reviewId = comment.getReview() != null ? comment.getReview().getId() : null;
+
 		return CommentDeleteResponse.builder()
-			.postId(comment.getPost().getId())
 			.commentId(comment.getId())
+			.postId(postId)
+			.reviewId(reviewId)
 			.userId(comment.getUserId())
 			.deleted(comment.getDeleted())
 			.build();

--- a/src/main/java/com/trendist/post_service/domain/comment/dto/response/CommentGetAllResponse.java
+++ b/src/main/java/com/trendist/post_service/domain/comment/dto/response/CommentGetAllResponse.java
@@ -11,6 +11,7 @@ import lombok.Builder;
 public record CommentGetAllResponse(
 	UUID commentId,
 	UUID postId,
+	UUID reviewId,
 	UUID userId,
 	String nickname,
 	String profileUrl,
@@ -18,9 +19,13 @@ public record CommentGetAllResponse(
 	LocalDateTime createdAt
 ) {
 	public static CommentGetAllResponse of(Comment comment, String nickname, String profileUrl) {
+		UUID postId = comment.getPost() != null ? comment.getPost().getId() : null;
+		UUID reviewId = comment.getReview() != null ? comment.getReview().getId() : null;
+
 		return CommentGetAllResponse.builder()
 			.commentId(comment.getId())
-			.postId(comment.getPost().getId())
+			.postId(postId)
+			.reviewId(reviewId)
 			.userId(comment.getUserId())
 			.nickname(nickname)
 			.profileUrl(profileUrl)

--- a/src/main/java/com/trendist/post_service/domain/comment/dto/response/CommentGetAllResponse.java
+++ b/src/main/java/com/trendist/post_service/domain/comment/dto/response/CommentGetAllResponse.java
@@ -8,18 +8,22 @@ import com.trendist.post_service.domain.comment.domain.Comment;
 import lombok.Builder;
 
 @Builder
-public record CommentCreateResponse(
+public record CommentGetAllResponse(
 	UUID commentId,
 	UUID postId,
 	UUID userId,
+	String nickname,
+	String profileUrl,
 	String content,
 	LocalDateTime createdAt
 ) {
-	public static CommentCreateResponse from(Comment comment) {
-		return CommentCreateResponse.builder()
+	public static CommentGetAllResponse of(Comment comment, String nickname, String profileUrl) {
+		return CommentGetAllResponse.builder()
 			.commentId(comment.getId())
 			.postId(comment.getPost().getId())
 			.userId(comment.getUserId())
+			.nickname(nickname)
+			.profileUrl(profileUrl)
 			.content(comment.getContent())
 			.createdAt(comment.getCreatedAt())
 			.build();

--- a/src/main/java/com/trendist/post_service/domain/comment/dto/response/CommentUpdateResponse.java
+++ b/src/main/java/com/trendist/post_service/domain/comment/dto/response/CommentUpdateResponse.java
@@ -1,0 +1,27 @@
+package com.trendist.post_service.domain.comment.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import com.trendist.post_service.domain.comment.domain.Comment;
+
+import lombok.Builder;
+
+@Builder
+public record CommentUpdateResponse(
+	UUID commentId,
+	UUID postId,
+	UUID userId,
+	String content,
+	LocalDateTime updatedAt
+) {
+	public static CommentUpdateResponse from(Comment comment) {
+		return CommentUpdateResponse.builder()
+			.commentId(comment.getId())
+			.postId(comment.getPost().getId())
+			.userId(comment.getUserId())
+			.content(comment.getContent())
+			.updatedAt(comment.getUpdatedAt())
+			.build();
+	}
+}

--- a/src/main/java/com/trendist/post_service/domain/comment/dto/response/CommentUpdateResponse.java
+++ b/src/main/java/com/trendist/post_service/domain/comment/dto/response/CommentUpdateResponse.java
@@ -11,14 +11,19 @@ import lombok.Builder;
 public record CommentUpdateResponse(
 	UUID commentId,
 	UUID postId,
+	UUID reviewId,
 	UUID userId,
 	String content,
 	LocalDateTime updatedAt
 ) {
 	public static CommentUpdateResponse from(Comment comment) {
+		UUID postId = comment.getPost() != null ? comment.getPost().getId() : null;
+		UUID reviewId = comment.getReview() != null ? comment.getReview().getId() : null;
+
 		return CommentUpdateResponse.builder()
 			.commentId(comment.getId())
-			.postId(comment.getPost().getId())
+			.postId(postId)
+			.reviewId(reviewId)
 			.userId(comment.getUserId())
 			.content(comment.getContent())
 			.updatedAt(comment.getUpdatedAt())

--- a/src/main/java/com/trendist/post_service/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/trendist/post_service/domain/comment/repository/CommentRepository.java
@@ -1,0 +1,10 @@
+package com.trendist.post_service.domain.comment.repository;
+
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.trendist.post_service.domain.comment.domain.Comment;
+
+public interface CommentRepository extends JpaRepository<Comment, UUID> {
+}

--- a/src/main/java/com/trendist/post_service/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/trendist/post_service/domain/comment/repository/CommentRepository.java
@@ -1,6 +1,7 @@
 package com.trendist.post_service.domain.comment.repository;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,4 +10,6 @@ import com.trendist.post_service.domain.comment.domain.Comment;
 
 public interface CommentRepository extends JpaRepository<Comment, UUID> {
 	List<Comment> findAllByPostId(UUID postId);
+
+	Optional<Comment> findById(UUID commentId);
 }

--- a/src/main/java/com/trendist/post_service/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/trendist/post_service/domain/comment/repository/CommentRepository.java
@@ -9,7 +9,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.trendist.post_service.domain.comment.domain.Comment;
 
 public interface CommentRepository extends JpaRepository<Comment, UUID> {
-	List<Comment> findAllByPostId(UUID postId);
+	List<Comment> findAllByPostIdAndDeletedFalse(UUID postId);
 
-	Optional<Comment> findById(UUID commentId);
+	Optional<Comment> findByIdAndDeletedFalse(UUID commentId);
 }

--- a/src/main/java/com/trendist/post_service/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/trendist/post_service/domain/comment/repository/CommentRepository.java
@@ -1,5 +1,6 @@
 package com.trendist.post_service.domain.comment.repository;
 
+import java.util.List;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -7,4 +8,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.trendist.post_service.domain.comment.domain.Comment;
 
 public interface CommentRepository extends JpaRepository<Comment, UUID> {
+	List<Comment> findAllByPostId(UUID postId);
 }

--- a/src/main/java/com/trendist/post_service/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/trendist/post_service/domain/comment/repository/CommentRepository.java
@@ -11,5 +11,7 @@ import com.trendist.post_service.domain.comment.domain.Comment;
 public interface CommentRepository extends JpaRepository<Comment, UUID> {
 	List<Comment> findAllByPostIdAndDeletedFalse(UUID postId);
 
+	List<Comment> findAllByReviewIdAndDeletedFalse(UUID reviewId);
+
 	Optional<Comment> findByIdAndDeletedFalse(UUID commentId);
 }

--- a/src/main/java/com/trendist/post_service/domain/comment/service/CommentService.java
+++ b/src/main/java/com/trendist/post_service/domain/comment/service/CommentService.java
@@ -1,6 +1,7 @@
 package com.trendist.post_service.domain.comment.service;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.stereotype.Service;
@@ -14,6 +15,8 @@ import com.trendist.post_service.domain.comment.dto.response.CommentUpdateRespon
 import com.trendist.post_service.domain.comment.repository.CommentRepository;
 import com.trendist.post_service.domain.post.domain.Post;
 import com.trendist.post_service.domain.post.repository.PostRepository;
+import com.trendist.post_service.domain.review.domain.Review;
+import com.trendist.post_service.domain.review.repository.ReviewRepository;
 import com.trendist.post_service.global.exception.ApiException;
 import com.trendist.post_service.global.feign.user.client.UserServiceClient;
 import com.trendist.post_service.global.feign.user.dto.UserProfileResponse;
@@ -28,22 +31,33 @@ public class CommentService {
 	private final CommentRepository commentRepository;
 	private final UserServiceClient userServiceClient;
 	private final PostRepository postRepository;
+	private final ReviewRepository reviewRepository;
 
 	@Transactional
-	public CommentCreateResponse createComment(UUID postId, CommentCreateOrUpdateRequest commentCreateOrUpdateRequest) {
+	public CommentCreateResponse createComment(UUID id, CommentCreateOrUpdateRequest commentCreateOrUpdateRequest) {
 		UUID userId = userServiceClient.getMyProfile("").getResult().id();
 
-		Post post = postRepository.findByIdAndDeletedFalse(postId)
-			.orElseThrow(() -> new ApiException(ErrorStatus._POST_NOT_FOUND));
+		Comment comment;
 
-		Comment comment = Comment.builder()
-			.post(post)
-			.userId(userId)
-			.content(commentCreateOrUpdateRequest.content())
-			.build();
+		Optional<Post> post = postRepository.findByIdAndDeletedFalse(id);
+		if (post.isPresent()) {
+			comment = Comment.builder()
+				.post(post.get())
+				.userId(userId)
+				.content(commentCreateOrUpdateRequest.content())
+				.build();
+		} else {
+			Review review = reviewRepository.findByIdAndDeletedFalse(id)
+				.orElseThrow(() -> new ApiException(ErrorStatus._REVIEW_NOT_FOUND));
+
+			comment = Comment.builder()
+				.review(review)
+				.userId(userId)
+				.content(commentCreateOrUpdateRequest.content())
+				.build();
+		}
 
 		commentRepository.save(comment);
-
 		return CommentCreateResponse.from(comment);
 	}
 
@@ -53,11 +67,10 @@ public class CommentService {
 		UUID userId = userServiceClient.getMyProfile("").getResult().id();
 
 		Comment comment = commentRepository.findByIdAndDeletedFalse(commentId)
-			.orElseThrow(() -> new ApiException(ErrorStatus._POST_NOT_FOUND));
-		//충돌 안나게 ErrorStatus 추가는 리뷰 작업 끝나고 진행
+			.orElseThrow(() -> new ApiException(ErrorStatus._COMMENT_NOT_FOUND));
 
 		if (!userId.equals(comment.getUserId())) {
-			throw new ApiException(ErrorStatus._POST_UPDATE_FORBIDDEN);
+			throw new ApiException(ErrorStatus._COMMENT_UPDATE_FORBIDDEN);
 			//충돌안나게 ErrorStatus 추가는 리뷰 작업 끝나고 진행
 		}
 
@@ -72,11 +85,11 @@ public class CommentService {
 		UUID userId = userServiceClient.getMyProfile("").getResult().id();
 
 		Comment comment = commentRepository.findByIdAndDeletedFalse(commentId)
-			.orElseThrow(() -> new ApiException(ErrorStatus._POST_NOT_FOUND));
+			.orElseThrow(() -> new ApiException(ErrorStatus._COMMENT_NOT_FOUND));
 		//충돌 안나게 ErrorStatus 추가는 리뷰 작업 끝나고 진행
 
 		if (!userId.equals(comment.getUserId())) {
-			throw new ApiException(ErrorStatus._POST_UPDATE_FORBIDDEN);
+			throw new ApiException(ErrorStatus._COMMENT_DELETE_FORBIDDEN);
 			//충돌안나게 ErrorStatus 추가는 리뷰 작업 끝나고 진행
 		}
 
@@ -86,8 +99,14 @@ public class CommentService {
 		return CommentDeleteResponse.from(comment);
 	}
 
-	public List<CommentGetAllResponse> getPostComments(UUID postId) {
-		List<Comment> comments = commentRepository.findAllByPostIdAndDeletedFalse(postId);
+	public List<CommentGetAllResponse> getPostComments(UUID id) {
+		List<Comment> comments = postRepository.findByIdAndDeletedFalse(id)
+			.map(post -> commentRepository.findAllByPostIdAndDeletedFalse(id))
+			.orElseGet(() -> {
+				reviewRepository.findByIdAndDeletedFalse(id)
+					.orElseThrow(() -> new ApiException(ErrorStatus._REVIEW_NOT_FOUND));
+				return commentRepository.findAllByReviewIdAndDeletedFalse(id);
+			});
 
 		return comments.stream()
 			.map(comment -> {

--- a/src/main/java/com/trendist/post_service/domain/comment/service/CommentService.java
+++ b/src/main/java/com/trendist/post_service/domain/comment/service/CommentService.java
@@ -71,7 +71,6 @@ public class CommentService {
 
 		if (!userId.equals(comment.getUserId())) {
 			throw new ApiException(ErrorStatus._COMMENT_UPDATE_FORBIDDEN);
-			//충돌안나게 ErrorStatus 추가는 리뷰 작업 끝나고 진행
 		}
 
 		comment.setContent(commentCreateOrUpdateRequest.content());
@@ -86,11 +85,9 @@ public class CommentService {
 
 		Comment comment = commentRepository.findByIdAndDeletedFalse(commentId)
 			.orElseThrow(() -> new ApiException(ErrorStatus._COMMENT_NOT_FOUND));
-		//충돌 안나게 ErrorStatus 추가는 리뷰 작업 끝나고 진행
 
 		if (!userId.equals(comment.getUserId())) {
 			throw new ApiException(ErrorStatus._COMMENT_DELETE_FORBIDDEN);
-			//충돌안나게 ErrorStatus 추가는 리뷰 작업 끝나고 진행
 		}
 
 		comment.setDeleted(true);

--- a/src/main/java/com/trendist/post_service/domain/comment/service/CommentService.java
+++ b/src/main/java/com/trendist/post_service/domain/comment/service/CommentService.java
@@ -1,5 +1,6 @@
 package com.trendist.post_service.domain.comment.service;
 
+import java.util.List;
 import java.util.UUID;
 
 import org.springframework.stereotype.Service;
@@ -7,11 +8,13 @@ import org.springframework.stereotype.Service;
 import com.trendist.post_service.domain.comment.domain.Comment;
 import com.trendist.post_service.domain.comment.dto.request.CommentCreateRequest;
 import com.trendist.post_service.domain.comment.dto.response.CommentCreateResponse;
+import com.trendist.post_service.domain.comment.dto.response.CommentGetAllResponse;
 import com.trendist.post_service.domain.comment.repository.CommentRepository;
 import com.trendist.post_service.domain.post.domain.Post;
 import com.trendist.post_service.domain.post.repository.PostRepository;
 import com.trendist.post_service.global.exception.ApiException;
 import com.trendist.post_service.global.feign.user.client.UserServiceClient;
+import com.trendist.post_service.global.feign.user.dto.UserProfileResponse;
 import com.trendist.post_service.global.response.status.ErrorStatus;
 
 import jakarta.transaction.Transactional;
@@ -27,8 +30,6 @@ public class CommentService {
 	@Transactional
 	public CommentCreateResponse createComment(UUID postId, CommentCreateRequest commentCreateRequest) {
 		UUID userId = userServiceClient.getMyProfile("").getResult().id();
-		String nickname = userServiceClient.getMyProfile("").getResult().nickname();
-		String profileUrl = userServiceClient.getMyProfile("").getResult().profileUrl();
 
 		Post post = postRepository.findByIdAndDeletedFalse(postId)
 			.orElseThrow(() -> new ApiException(ErrorStatus._POST_NOT_FOUND));
@@ -41,6 +42,17 @@ public class CommentService {
 
 		commentRepository.save(comment);
 
-		return CommentCreateResponse.of(comment, nickname, profileUrl);
+		return CommentCreateResponse.from(comment);
+	}
+
+	public List<CommentGetAllResponse> getPostComments(UUID postId) {
+		List<Comment> comments = commentRepository.findAllByPostId(postId);
+
+		return comments.stream()
+			.map(comment -> {
+				UserProfileResponse user = userServiceClient.getUserProfile(comment.getUserId()).getResult();
+				return CommentGetAllResponse.of(comment, user.nickname(), user.profileUrl());
+			})
+			.toList();
 	}
 }

--- a/src/main/java/com/trendist/post_service/domain/comment/service/CommentService.java
+++ b/src/main/java/com/trendist/post_service/domain/comment/service/CommentService.java
@@ -6,9 +6,10 @@ import java.util.UUID;
 import org.springframework.stereotype.Service;
 
 import com.trendist.post_service.domain.comment.domain.Comment;
-import com.trendist.post_service.domain.comment.dto.request.CommentCreateRequest;
+import com.trendist.post_service.domain.comment.dto.request.CommentCreateOrUpdateRequest;
 import com.trendist.post_service.domain.comment.dto.response.CommentCreateResponse;
 import com.trendist.post_service.domain.comment.dto.response.CommentGetAllResponse;
+import com.trendist.post_service.domain.comment.dto.response.CommentUpdateResponse;
 import com.trendist.post_service.domain.comment.repository.CommentRepository;
 import com.trendist.post_service.domain.post.domain.Post;
 import com.trendist.post_service.domain.post.repository.PostRepository;
@@ -28,7 +29,7 @@ public class CommentService {
 	private final PostRepository postRepository;
 
 	@Transactional
-	public CommentCreateResponse createComment(UUID postId, CommentCreateRequest commentCreateRequest) {
+	public CommentCreateResponse createComment(UUID postId, CommentCreateOrUpdateRequest commentCreateOrUpdateRequest) {
 		UUID userId = userServiceClient.getMyProfile("").getResult().id();
 
 		Post post = postRepository.findByIdAndDeletedFalse(postId)
@@ -37,12 +38,32 @@ public class CommentService {
 		Comment comment = Comment.builder()
 			.post(post)
 			.userId(userId)
-			.content(commentCreateRequest.content())
+			.content(commentCreateOrUpdateRequest.content())
 			.build();
 
 		commentRepository.save(comment);
 
 		return CommentCreateResponse.from(comment);
+	}
+
+	@Transactional
+	public CommentUpdateResponse updateComment(UUID commentId,
+		CommentCreateOrUpdateRequest commentCreateOrUpdateRequest) {
+		UUID userId = userServiceClient.getMyProfile("").getResult().id();
+
+		Comment comment = commentRepository.findById(commentId)
+			.orElseThrow(() -> new ApiException(ErrorStatus._POST_NOT_FOUND));
+		//충돌 안나게 ErrorStatus 추가는 리뷰 작업 끝나고 진행
+
+		if (!userId.equals(comment.getUserId())) {
+			throw new ApiException(ErrorStatus._POST_UPDATE_FORBIDDEN);
+			//충돌안나게 ErrorStatus 추가는 리뷰 작업 끝나고 진행
+		}
+
+		comment.setContent(commentCreateOrUpdateRequest.content());
+		commentRepository.save(comment);
+
+		return CommentUpdateResponse.from(comment);
 	}
 
 	public List<CommentGetAllResponse> getPostComments(UUID postId) {

--- a/src/main/java/com/trendist/post_service/domain/post/controller/PostController.java
+++ b/src/main/java/com/trendist/post_service/domain/post/controller/PostController.java
@@ -17,6 +17,7 @@ import com.trendist.post_service.domain.post.dto.response.PostDeleteResponse;
 import com.trendist.post_service.domain.post.dto.response.PostGetAllResponse;
 import com.trendist.post_service.domain.post.dto.response.PostGetMineResponse;
 import com.trendist.post_service.domain.post.dto.response.PostGetResponse;
+import com.trendist.post_service.domain.post.dto.response.PostLikeResponse;
 import com.trendist.post_service.domain.post.dto.response.PostUpdateResponse;
 import com.trendist.post_service.global.response.ApiResponse;
 import com.trendist.post_service.domain.post.dto.request.PostCreateRequest;
@@ -86,5 +87,14 @@ public class PostController {
 	@GetMapping("/mine")
 	public ApiResponse<Page<PostGetMineResponse>> getMyPosts(@RequestParam(defaultValue = "0") int page) {
 		return ApiResponse.onSuccess(postService.getMyPosts(page));
+	}
+
+	@Operation(
+		summary = "자유 게시판 게시물 좋아요",
+		description = "사용자가 자유 게시판에 있는 특정 게시물에 좋아요를 누르거나 취소합니다."
+	)
+	@PostMapping("/{postId}/like")
+	public ApiResponse<PostLikeResponse> likePost(@PathVariable(name = "postId") UUID postId) {
+		return ApiResponse.onSuccess(postService.likePost(postId));
 	}
 }

--- a/src/main/java/com/trendist/post_service/domain/post/controller/PostController.java
+++ b/src/main/java/com/trendist/post_service/domain/post/controller/PostController.java
@@ -72,6 +72,15 @@ public class PostController {
 	}
 
 	@Operation(
+		summary = "자유 게시판 전체 게시물 좋아요 순 조회",
+		description = "자유 게시판에 전체 게시물을 좋아요가 많은 순으로 조회합니다."
+	)
+	@GetMapping("/like")
+	public ApiResponse<Page<PostGetAllResponse>> getAllPostsByLikeCount(@RequestParam(defaultValue = "0") int page) {
+		return ApiResponse.onSuccess(postService.getAllPostsByLikeCount(page));
+	}
+
+	@Operation(
 		summary = "자유 게시판 특정 게시물 조회",
 		description = "사용자가 자유 게시판에 있는 특정 게시물을 상세 조회합니다."
 	)

--- a/src/main/java/com/trendist/post_service/domain/post/domain/Post.java
+++ b/src/main/java/com/trendist/post_service/domain/post/domain/Post.java
@@ -49,6 +49,10 @@ public class Post extends BaseTimeEntity {
 	@Column(name = "image_urls")
 	private List<String> imageUrls;
 
+	@Column(name = "post_like_count")
+	@Builder.Default
+	private Integer likeCount = 0;
+
 	@Column(name = "deleted")
 	@Builder.Default
 	private Boolean deleted = false;

--- a/src/main/java/com/trendist/post_service/domain/post/domain/PostLike.java
+++ b/src/main/java/com/trendist/post_service/domain/post/domain/PostLike.java
@@ -1,0 +1,45 @@
+package com.trendist.post_service.domain.post.domain;
+
+import java.util.UUID;
+
+import com.trendist.post_service.global.common.domain.BaseTimeEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(
+	name = "post_likes",
+	uniqueConstraints = @UniqueConstraint(columnNames = {"post_id","user_id"})
+)
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostLike extends BaseTimeEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.UUID)
+	private UUID id;
+
+	@Column(name = "post_id")
+	private UUID postId;
+
+	@Column(name = "user_id")
+	private UUID userId;
+
+	public PostLike(UUID postId, UUID userId){
+		this.postId = postId;
+		this.userId = userId;
+	}
+}

--- a/src/main/java/com/trendist/post_service/domain/post/dto/response/PostGetAllResponse.java
+++ b/src/main/java/com/trendist/post_service/domain/post/dto/response/PostGetAllResponse.java
@@ -12,6 +12,7 @@ public record PostGetAllResponse(
 	UUID id,
 	String title,
 	String nickname,
+	Integer likeCount,
 	LocalDateTime createdAt
 	//좋아요 수도 추가되어야함
 ) {
@@ -20,6 +21,7 @@ public record PostGetAllResponse(
 			.id(post.getId())
 			.title(post.getTitle())
 			.nickname(post.getNickname())
+			.likeCount(post.getLikeCount())
 			.createdAt(post.getCreatedAt())
 			.build();
 	}

--- a/src/main/java/com/trendist/post_service/domain/post/dto/response/PostGetResponse.java
+++ b/src/main/java/com/trendist/post_service/domain/post/dto/response/PostGetResponse.java
@@ -12,6 +12,7 @@ public record PostGetResponse(
 	UUID id,
 	String title,
 	String content,
+	Integer likeCount,
 	UUID userId,
 	String nickname,
 	String profileUrl,
@@ -23,6 +24,7 @@ public record PostGetResponse(
 			.id(post.getId())
 			.title(post.getTitle())
 			.content(post.getContent())
+			.likeCount(post.getLikeCount())
 			.userId(post.getUserId())
 			.nickname(post.getNickname())
 			.profileUrl(profileUrl)

--- a/src/main/java/com/trendist/post_service/domain/post/dto/response/PostLikeResponse.java
+++ b/src/main/java/com/trendist/post_service/domain/post/dto/response/PostLikeResponse.java
@@ -1,0 +1,24 @@
+package com.trendist.post_service.domain.post.dto.response;
+
+import java.util.UUID;
+
+import com.trendist.post_service.domain.post.domain.PostLike;
+
+import lombok.Builder;
+
+@Builder
+public record PostLikeResponse(
+	UUID likeId,
+	UUID postId,
+	UUID userId,
+	Boolean like
+) {
+	public static PostLikeResponse of(PostLike postLike, Boolean like) {
+		return PostLikeResponse.builder()
+			.likeId(postLike.getId())
+			.postId(postLike.getPostId())
+			.userId(postLike.getUserId())
+			.like(like)
+			.build();
+	}
+}

--- a/src/main/java/com/trendist/post_service/domain/post/repository/PostLikeRepository.java
+++ b/src/main/java/com/trendist/post_service/domain/post/repository/PostLikeRepository.java
@@ -1,0 +1,16 @@
+package com.trendist.post_service.domain.post.repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.trendist.post_service.domain.post.domain.PostLike;
+
+public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
+	Optional<PostLike> findByPostIdAndUserId(UUID postId, UUID userId);
+
+	boolean existsByPostIdAndUserId(UUID postId, UUID userId);
+
+	void deleteByPostIdAndUserId(UUID postId, UUID userId);
+}

--- a/src/main/java/com/trendist/post_service/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/trendist/post_service/domain/post/repository/PostRepository.java
@@ -6,6 +6,9 @@ import java.util.UUID;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.trendist.post_service.domain.post.domain.Post;
 
@@ -15,4 +18,12 @@ public interface PostRepository extends JpaRepository<Post, UUID> {
 	Optional<Post> findByIdAndDeletedFalse(UUID postId);
 
 	Page<Post> findByUserIdAndDeletedFalse(UUID userId, Pageable pageable);
+
+	@Modifying
+	@Query("UPDATE posts p SET p.likeCount = p.likeCount + 1 WHERE p.id = :postId")
+	void incrementLikeCount(@Param("postId") UUID postId);
+
+	@Modifying
+	@Query("UPDATE posts p SET p.likeCount = p.likeCount - 1 WHERE p.id = :postId AND p.likeCount > 0")
+	void decrementLikeCount(@Param("postId") UUID postId);
 }

--- a/src/main/java/com/trendist/post_service/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/trendist/post_service/domain/post/repository/PostRepository.java
@@ -15,6 +15,8 @@ import com.trendist.post_service.domain.post.domain.Post;
 public interface PostRepository extends JpaRepository<Post, UUID> {
 	Page<Post> findAllByDeletedFalse(Pageable pageable);
 
+	Page<Post> findAllByDeletedFalseOrderByLikeCountDesc(Pageable pageable);
+
 	Optional<Post> findByIdAndDeletedFalse(UUID postId);
 
 	Page<Post> findByUserIdAndDeletedFalse(UUID userId, Pageable pageable);

--- a/src/main/java/com/trendist/post_service/domain/post/service/PostService.java
+++ b/src/main/java/com/trendist/post_service/domain/post/service/PostService.java
@@ -1,6 +1,5 @@
 package com.trendist.post_service.domain.post.service;
 
-import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.data.domain.Page;
@@ -93,6 +92,12 @@ public class PostService {
 	public Page<PostGetAllResponse> getAllPosts(int page) {
 		Pageable pageable = PageRequest.of(page, 10, Sort.by("createdAt").descending());
 		return postRepository.findAllByDeletedFalse(pageable)
+			.map(PostGetAllResponse::from);
+	}
+
+	public Page<PostGetAllResponse> getAllPostsByLikeCount(int page) {
+		Pageable pageable = PageRequest.of(page, 10);
+		return postRepository.findAllByDeletedFalseOrderByLikeCountDesc(pageable)
 			.map(PostGetAllResponse::from);
 	}
 

--- a/src/main/java/com/trendist/post_service/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/trendist/post_service/domain/review/controller/ReviewController.java
@@ -19,6 +19,7 @@ import com.trendist.post_service.domain.review.dto.response.ReviewDeleteResponse
 import com.trendist.post_service.domain.review.dto.response.ReviewGetAllResponse;
 import com.trendist.post_service.domain.review.dto.response.ReviewGetMineResponse;
 import com.trendist.post_service.domain.review.dto.response.ReviewGetResponse;
+import com.trendist.post_service.domain.review.dto.response.ReviewLikeResponse;
 import com.trendist.post_service.domain.review.dto.response.ReviewUpdateResponse;
 import com.trendist.post_service.domain.review.service.ReviewService;
 import com.trendist.post_service.global.response.ApiResponse;
@@ -88,4 +89,12 @@ public class ReviewController {
 		return ApiResponse.onSuccess(reviewService.getMyReviews(page));
 	}
 
+	@Operation(
+		summary = "리뷰 게시물 좋아요",
+		description = "사용자가 리뷰 게시판에 있는 특정 게시물에 좋아요를 누르거나 취소합니다."
+	)
+	@PostMapping("/{reviewId}/like")
+	public ApiResponse<ReviewLikeResponse> likeReview(@PathVariable(name = "reviewId") UUID reviewId) {
+		return ApiResponse.onSuccess(reviewService.likeReview(reviewId));
+	}
 }

--- a/src/main/java/com/trendist/post_service/domain/review/domain/Review.java
+++ b/src/main/java/com/trendist/post_service/domain/review/domain/Review.java
@@ -75,6 +75,10 @@ public class Review extends BaseTimeEntity {
 	@Column(name = "image_urls")
 	private List<String> imageUrls;
 
+	@Column(name = "review_like_count")
+	@Builder.Default
+	private Integer likeCount = 0;
+
 	@Column(name = "deleted")
 	@Builder.Default
 	private Boolean deleted = false;

--- a/src/main/java/com/trendist/post_service/domain/review/domain/ReviewLike.java
+++ b/src/main/java/com/trendist/post_service/domain/review/domain/ReviewLike.java
@@ -1,0 +1,43 @@
+package com.trendist.post_service.domain.review.domain;
+
+import java.util.UUID;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(
+	name = "review_likes",
+	uniqueConstraints = @UniqueConstraint(columnNames = {"review_id","user_id"})
+)
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReviewLike {
+	@Id
+	@GeneratedValue(strategy = GenerationType.UUID)
+	private UUID id;
+
+	@Column(name = "review_id")
+	private UUID reviewId;
+
+	@Column(name = "user_id")
+	private UUID userId;
+
+	public ReviewLike(UUID reviewId, UUID userId){
+		this.reviewId = reviewId;
+		this.userId = userId;
+	}
+}

--- a/src/main/java/com/trendist/post_service/domain/review/dto/response/ReviewGetAllResponse.java
+++ b/src/main/java/com/trendist/post_service/domain/review/dto/response/ReviewGetAllResponse.java
@@ -12,6 +12,7 @@ public record ReviewGetAllResponse(
 	UUID id,
 	String title,
 	String nickname,
+	Integer likeCount,
 	LocalDateTime createAt
 	//좋아요 수 추가예정
 ) {
@@ -20,6 +21,7 @@ public record ReviewGetAllResponse(
 			.id(review.getId())
 			.title(review.getTitle())
 			.nickname(review.getNickname())
+			.likeCount(review.getLikeCount())
 			.createAt(review.getCreatedAt())
 			.build();
 	}

--- a/src/main/java/com/trendist/post_service/domain/review/dto/response/ReviewGetResponse.java
+++ b/src/main/java/com/trendist/post_service/domain/review/dto/response/ReviewGetResponse.java
@@ -21,6 +21,7 @@ public record ReviewGetResponse(
 	LocalDate activityEndDate,
 	String activityName,
 	String content,
+	Integer likeCount,
 	UUID userId,
 	String nickname,
 	String profileUrl,
@@ -36,6 +37,7 @@ public record ReviewGetResponse(
 			.activityEndDate(review.getActivityEndDate())
 			.activityName(review.getActivityName())
 			.content(review.getContent())
+			.likeCount(review.getLikeCount())
 			.userId(review.getUserId())
 			.nickname(review.getNickname())
 			.profileUrl(profileUrl)

--- a/src/main/java/com/trendist/post_service/domain/review/dto/response/ReviewLikeResponse.java
+++ b/src/main/java/com/trendist/post_service/domain/review/dto/response/ReviewLikeResponse.java
@@ -1,0 +1,24 @@
+package com.trendist.post_service.domain.review.dto.response;
+
+import java.util.UUID;
+
+import com.trendist.post_service.domain.review.domain.ReviewLike;
+
+import lombok.Builder;
+
+@Builder
+public record ReviewLikeResponse(
+	UUID likeId,
+	UUID reviewId,
+	UUID userId,
+	Boolean like
+) {
+	public static ReviewLikeResponse of(ReviewLike reviewLike, Boolean like) {
+		return ReviewLikeResponse.builder()
+			.likeId(reviewLike.getId())
+			.reviewId(reviewLike.getReviewId())
+			.userId(reviewLike.getUserId())
+			.like(like)
+			.build();
+	}
+}

--- a/src/main/java/com/trendist/post_service/domain/review/repository/ReviewLikeRepository.java
+++ b/src/main/java/com/trendist/post_service/domain/review/repository/ReviewLikeRepository.java
@@ -1,0 +1,16 @@
+package com.trendist.post_service.domain.review.repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.trendist.post_service.domain.review.domain.ReviewLike;
+
+public interface ReviewLikeRepository extends JpaRepository<ReviewLike, UUID> {
+	Optional<ReviewLike> findByReviewIdAndUserId(UUID reviewId, UUID userId);
+
+	boolean existsByReviewIdAndUserId(UUID reviewId, UUID userId);
+
+	void deleteByReviewIdAndUserId(UUID postId, UUID userId);
+}

--- a/src/main/java/com/trendist/post_service/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/trendist/post_service/domain/review/repository/ReviewRepository.java
@@ -6,6 +6,9 @@ import java.util.UUID;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.trendist.post_service.domain.review.domain.Review;
 
@@ -15,4 +18,12 @@ public interface ReviewRepository extends JpaRepository<Review, UUID> {
 	Optional<Review> findByIdAndDeletedFalse(UUID id);
 
 	Page<Review> findByUserIdAndDeletedFalse(UUID id, Pageable pageable);
+
+	@Modifying
+	@Query("UPDATE reviews r SET r.likeCount = r.likeCount + 1 WHERE r.id = :reviewId")
+	void incrementLikeCount(@Param("reviewId") UUID reviewId);
+
+	@Modifying
+	@Query("UPDATE reviews r SET r.likeCount = r.likeCount - 1 WHERE r.id = :reviewId AND r.likeCount > 0")
+	void decrementLikeCount(@Param("reviewId") UUID reviewId);
 }

--- a/src/main/java/com/trendist/post_service/global/response/status/ErrorStatus.java
+++ b/src/main/java/com/trendist/post_service/global/response/status/ErrorStatus.java
@@ -33,6 +33,10 @@ public enum ErrorStatus implements BaseErrorCode {
 	_REVIEW_DELETE_FORBIDDEN(HttpStatus.FORBIDDEN, "REVIEW_003", "게시물을 삭제 요청이 거부되었습니다."),
 	_REVIEW_IMAGE_REQUIRED(HttpStatus.BAD_REQUEST, "REVIEW_004", "리뷰에는 최소 1개의 이미지를 첨부해야 합니다."),
 
+	_COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMENT_001", "해당 댓글이 존재하지 않습니다."),
+	_COMMENT_UPDATE_FORBIDDEN(HttpStatus.FORBIDDEN, "COMMENT_002", "댓글 수정 요청이 거부되었습니다."),
+	_COMMENT_DELETE_FORBIDDEN(HttpStatus.FORBIDDEN, "COMMENT_003", "댓글 삭제 요청이 거부되었습니다."),
+
 	//s3 관련
 	_S3_OVER_MAX_FILES(HttpStatus.BAD_REQUEST, "s3_001", "최대 파일 수를 초과하였습니다.");
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,7 +23,7 @@ spring:
     database: mysql
     show-sql: true
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         format_sql: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,7 +23,7 @@ spring:
     database: mysql
     show-sql: true
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     properties:
       hibernate:
         format_sql: true


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [x] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [x] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용
### 1. 댓글 기능을 구현하였습니다.
**1-1. 댓글 생성**
- 댓글 생성의 경우 경로의 id를 통해 post를 검색하고 만약 없을 경우 review를 검색하여 댓글을 작성하도록, 즉 post, review 게시물에 대한 댓글 작성을 하나에서 진행하였습니다. 
<img width="831" alt="image" src="https://github.com/user-attachments/assets/82184d38-50e5-4188-8cea-82cf4324be75" />

**1-2. 댓글 수정**
<img width="830" alt="image" src="https://github.com/user-attachments/assets/12d39394-8d89-4826-9255-af5154372327" />

**1-3. 댓글 삭제**
<img width="829" alt="image" src="https://github.com/user-attachments/assets/a0524d4b-bd22-471b-a2e9-0e8961acdeff" />

**1-4. 특정 게시물의 전체 댓글들 조회**
<img width="829" alt="image" src="https://github.com/user-attachments/assets/739d6e05-eee6-4d6a-85d6-4d8e5a14889e" />

### 2. 좋아요 기능을 구현하였습니다.
**우선 좋아요 기능의 경우 리뷰와 자유게시물에 대하여 두번 구현하였지만 코드가 거의 동일하기에 한번만 설명하겠습니다.**

**특정 게시물에 대한 좋아요 및 좋아요 취소**
- api를 하나만 구현하여 한번 버튼을 누르면 좋아요가 등록이 되고 다시 한번 누르면 좋아요가 취소가 되는 식으로 구현하였습니다.
- 동시성 문제를 고려하여 원자적 업데이트 방식을 사용하였습니다.
- 좋아요 취소의 경우 다른 삭제 기능들과 다르게 실제로 삭제가 되도록 구현하였습니다. 

**좋아요 등록**
<img width="828" alt="image" src="https://github.com/user-attachments/assets/edb3d606-23c0-4cf9-a9f0-0e74ccc1f599" />
**좋아요 취소**
<img width="828" alt="image" src="https://github.com/user-attachments/assets/16193938-2715-466a-b166-ab1f276a80da" />

**따라서 게시물 조회 시 좋아요 총 개수도 확인할 수 있게 하였습니다.**
<img width="832" alt="image" src="https://github.com/user-attachments/assets/ec54574e-135e-49fa-933b-226b69c48b0d" />

---

## 🔗 관련 이슈
- close #9 

---

## 💡 추가 사항
좋아요 기능의 경우 최소한의 동시성 문제 처리는 해놓았지만 아직 rare condition이 존재합니다. 만약 특정 사용자가 매우 연속적으로 버튼을 클릭하면 서버 오류가 생길 수 있습니다. 따라서 클라이언트 측에서 api 호출 중에는 버튼을 비활성화하여 버튼을 연속적으로 누를 수 없도록 해야합니다. 
