### PR TITLE
refactor: 리뷰 전체 조회, 정렬 기능 하나로 통합 구현

### DIFF
--- a/src/main/java/com/trendist/post_service/domain/post/controller/PostController.java
+++ b/src/main/java/com/trendist/post_service/domain/post/controller/PostController.java
@@ -15,7 +15,6 @@ import org.springframework.web.bind.annotation.RestController;
 import com.trendist.post_service.domain.post.dto.request.PostUpdateRequest;
 import com.trendist.post_service.domain.post.dto.response.PostDeleteResponse;
 import com.trendist.post_service.domain.post.dto.response.PostGetAllResponse;
-import com.trendist.post_service.domain.post.dto.response.PostGetMineResponse;
 import com.trendist.post_service.domain.post.dto.response.PostGetResponse;
 import com.trendist.post_service.domain.post.dto.response.PostLikeResponse;
 import com.trendist.post_service.domain.post.dto.response.PostUpdateResponse;
@@ -87,15 +86,6 @@ public class PostController {
 	@GetMapping("/{postId}")
 	public ApiResponse<PostGetResponse> getPost(@PathVariable(name = "postId") UUID postId) {
 		return ApiResponse.onSuccess(postService.getPost(postId));
-	}
-
-	@Operation(
-		summary = "내가 쓴 자유 게시판 게시물 조회",
-		description = "현재 로그인한 사용자가 자유 게시판에 자신이 생성한 게시물들을 조회합니다."
-	)
-	@GetMapping("/mine")
-	public ApiResponse<Page<PostGetMineResponse>> getMyPosts(@RequestParam(defaultValue = "0") int page) {
-		return ApiResponse.onSuccess(postService.getMyPosts(page));
 	}
 
 	@Operation(

--- a/src/main/java/com/trendist/post_service/domain/post/controller/PostProfileController.java
+++ b/src/main/java/com/trendist/post_service/domain/post/controller/PostProfileController.java
@@ -1,12 +1,15 @@
 package com.trendist.post_service.domain.post.controller;
 
+import java.util.UUID;
+
 import org.springframework.data.domain.Page;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.trendist.post_service.domain.post.dto.response.PostGetMineResponse;
+import com.trendist.post_service.domain.post.dto.response.PostGetUserResponse;
 import com.trendist.post_service.domain.post.service.PostProfileService;
 import com.trendist.post_service.global.response.ApiResponse;
 
@@ -24,7 +27,18 @@ public class PostProfileController {
 		description = "현재 로그인한 사용자가 자유 게시판에 자신이 생성한 게시물들을 조회합니다."
 	)
 	@GetMapping("/posts/mine")
-	public ApiResponse<Page<PostGetMineResponse>> getMyPosts(@RequestParam(defaultValue = "0") int page) {
+	public ApiResponse<Page<PostGetUserResponse>> getMyPosts(@RequestParam(defaultValue = "0") int page) {
 		return ApiResponse.onSuccess(postProfileService.getMyPosts(page));
+	}
+
+	@Operation(
+		summary = "특정 사용자가 쓴 자유 게시판 게시물 조회",
+		description = "특정 사용자가 자유 게시판에 본인이 생성한 게시물들을 조회합니다."
+	)
+	@GetMapping("/posts/{userId}")
+	public ApiResponse<Page<PostGetUserResponse>> getUserPosts(
+		@RequestParam(defaultValue = "0") int page,
+		@PathVariable(name = "userId") UUID userId) {
+		return ApiResponse.onSuccess(postProfileService.getUserPosts(page, userId));
 	}
 }

--- a/src/main/java/com/trendist/post_service/domain/post/controller/PostProfileController.java
+++ b/src/main/java/com/trendist/post_service/domain/post/controller/PostProfileController.java
@@ -1,0 +1,30 @@
+package com.trendist.post_service.domain.post.controller;
+
+import org.springframework.data.domain.Page;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.trendist.post_service.domain.post.dto.response.PostGetMineResponse;
+import com.trendist.post_service.domain.post.service.PostProfileService;
+import com.trendist.post_service.global.response.ApiResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/profile")
+public class PostProfileController {
+	private final PostProfileService postProfileService;
+
+	@Operation(
+		summary = "내가 쓴 자유 게시판 게시물 조회",
+		description = "현재 로그인한 사용자가 자유 게시판에 자신이 생성한 게시물들을 조회합니다."
+	)
+	@GetMapping("/posts/mine")
+	public ApiResponse<Page<PostGetMineResponse>> getMyPosts(@RequestParam(defaultValue = "0") int page) {
+		return ApiResponse.onSuccess(postProfileService.getMyPosts(page));
+	}
+}

--- a/src/main/java/com/trendist/post_service/domain/post/dto/response/PostGetUserResponse.java
+++ b/src/main/java/com/trendist/post_service/domain/post/dto/response/PostGetUserResponse.java
@@ -8,13 +8,13 @@ import com.trendist.post_service.domain.post.domain.Post;
 import lombok.Builder;
 
 @Builder
-public record PostGetMineResponse(
+public record PostGetUserResponse(
 	UUID id,
 	String title,
 	LocalDateTime updatedAt
 ) {
-	public static PostGetMineResponse from(Post post) {
-		return PostGetMineResponse.builder()
+	public static PostGetUserResponse from(Post post) {
+		return PostGetUserResponse.builder()
 			.id(post.getId())
 			.title(post.getTitle())
 			.updatedAt(post.getUpdatedAt())

--- a/src/main/java/com/trendist/post_service/domain/post/service/PostProfileService.java
+++ b/src/main/java/com/trendist/post_service/domain/post/service/PostProfileService.java
@@ -1,0 +1,30 @@
+package com.trendist.post_service.domain.post.service;
+
+import java.util.UUID;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+
+import com.trendist.post_service.domain.post.dto.response.PostGetMineResponse;
+import com.trendist.post_service.domain.post.repository.PostRepository;
+import com.trendist.post_service.global.feign.user.client.UserServiceClient;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class PostProfileService {
+	private final PostRepository postRepository;
+	private final UserServiceClient userServiceClient;
+
+	public Page<PostGetMineResponse> getMyPosts(int page) {
+		UUID userId = userServiceClient.getMyProfile("").getResult().id();
+		Pageable pageable = PageRequest.of(page, 10, Sort.by("updatedAt").descending());
+
+		return postRepository.findByUserIdAndDeletedFalse(userId, pageable)
+			.map(PostGetMineResponse::from);
+	}
+}

--- a/src/main/java/com/trendist/post_service/domain/post/service/PostProfileService.java
+++ b/src/main/java/com/trendist/post_service/domain/post/service/PostProfileService.java
@@ -8,7 +8,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
-import com.trendist.post_service.domain.post.dto.response.PostGetMineResponse;
+import com.trendist.post_service.domain.post.dto.response.PostGetUserResponse;
 import com.trendist.post_service.domain.post.repository.PostRepository;
 import com.trendist.post_service.global.feign.user.client.UserServiceClient;
 
@@ -20,11 +20,18 @@ public class PostProfileService {
 	private final PostRepository postRepository;
 	private final UserServiceClient userServiceClient;
 
-	public Page<PostGetMineResponse> getMyPosts(int page) {
+	public Page<PostGetUserResponse> getMyPosts(int page) {
 		UUID userId = userServiceClient.getMyProfile("").getResult().id();
 		Pageable pageable = PageRequest.of(page, 10, Sort.by("updatedAt").descending());
 
 		return postRepository.findByUserIdAndDeletedFalse(userId, pageable)
-			.map(PostGetMineResponse::from);
+			.map(PostGetUserResponse::from);
+	}
+
+	public Page<PostGetUserResponse> getUserPosts(int page, UUID userId) {
+		Pageable pageable = PageRequest.of(page, 10, Sort.by("updatedAt").descending());
+
+		return postRepository.findByUserIdAndDeletedFalse(userId, pageable)
+			.map(PostGetUserResponse::from);
 	}
 }

--- a/src/main/java/com/trendist/post_service/domain/post/service/PostService.java
+++ b/src/main/java/com/trendist/post_service/domain/post/service/PostService.java
@@ -12,7 +12,6 @@ import com.trendist.post_service.domain.post.domain.PostLike;
 import com.trendist.post_service.domain.post.dto.request.PostUpdateRequest;
 import com.trendist.post_service.domain.post.dto.response.PostDeleteResponse;
 import com.trendist.post_service.domain.post.dto.response.PostGetAllResponse;
-import com.trendist.post_service.domain.post.dto.response.PostGetMineResponse;
 import com.trendist.post_service.domain.post.dto.response.PostGetResponse;
 import com.trendist.post_service.domain.post.dto.response.PostLikeResponse;
 import com.trendist.post_service.domain.post.dto.response.PostUpdateResponse;
@@ -107,14 +106,6 @@ public class PostService {
 		String profileUrl = userServiceClient.getUserProfile(post.getUserId()).getResult().profileUrl();
 
 		return PostGetResponse.of(post, profileUrl);
-	}
-
-	public Page<PostGetMineResponse> getMyPosts(int page) {
-		UUID userId = userServiceClient.getMyProfile("").getResult().id();
-		Pageable pageable = PageRequest.of(page, 10, Sort.by("updatedAt").descending());
-
-		return postRepository.findByUserIdAndDeletedFalse(userId, pageable)
-			.map(PostGetMineResponse::from);
 	}
 
 	@Transactional

--- a/src/main/java/com/trendist/post_service/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/trendist/post_service/domain/review/controller/ReviewController.java
@@ -23,7 +23,7 @@ import com.trendist.post_service.domain.review.dto.response.ReviewDeleteResponse
 import com.trendist.post_service.domain.review.dto.response.ReviewGetAllResponse;
 import com.trendist.post_service.domain.review.dto.response.ReviewGetKeywordCountResponse;
 import com.trendist.post_service.domain.review.dto.response.ReviewGetTypeCountResponse;
-import com.trendist.post_service.domain.review.dto.response.ReviewGetMineResponse;
+import com.trendist.post_service.domain.review.dto.response.ReviewGetUserResponse;
 import com.trendist.post_service.domain.review.dto.response.ReviewGetResponse;
 import com.trendist.post_service.domain.review.dto.response.ReviewLikeResponse;
 import com.trendist.post_service.domain.review.dto.response.ReviewUpdateResponse;
@@ -93,11 +93,22 @@ public class ReviewController {
 
 	@Operation(
 		summary = "내가 쓴 리뷰 게시판 게시물 조회",
-		description = "현재 로그인한 사용자가 리뷰 게시판에 자신이 생성한 게시물들을 조회합니다."
+		description = "현재 로그인한 사용자가 리뷰 게시판에 자신이 생성한 게시물들을 조회합니다.(본인 프로필용)"
 	)
-	@GetMapping("/mine")
-	public ApiResponse<Page<ReviewGetMineResponse>> getMyReviews(@RequestParam(defaultValue = "0") int page) {
+	@GetMapping("/profile/mine")
+	public ApiResponse<Page<ReviewGetUserResponse>> getMyReviews(@RequestParam(defaultValue = "0") int page) {
 		return ApiResponse.onSuccess(reviewService.getMyReviews(page));
+	}
+
+	@Operation(
+		summary = " 특정 사용자가 쓴 리뷰 게시물 조회",
+		description = "특정 사용자가 리뷰 게시판에 본인이 생성한 게시물들을 조회합니다.(특정 사용자 프로필용)"
+	)
+	@GetMapping("/profile/{userId}")
+	public ApiResponse<Page<ReviewGetUserResponse>> getUserReviews(
+		@RequestParam(defaultValue = "0") int page,
+		@PathVariable(name = "userId") UUID userId) {
+		return ApiResponse.onSuccess(reviewService.getUserReviews(page, userId));
 	}
 
 	@Operation(

--- a/src/main/java/com/trendist/post_service/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/trendist/post_service/domain/review/controller/ReviewController.java
@@ -1,6 +1,5 @@
 package com.trendist.post_service.domain.review.controller;
 
-import java.util.List;
 import java.util.UUID;
 
 import org.springframework.data.domain.Page;
@@ -21,9 +20,6 @@ import com.trendist.post_service.domain.review.dto.request.ReviewUpdateRequest;
 import com.trendist.post_service.domain.review.dto.response.ReviewCreateResponse;
 import com.trendist.post_service.domain.review.dto.response.ReviewDeleteResponse;
 import com.trendist.post_service.domain.review.dto.response.ReviewGetAllResponse;
-import com.trendist.post_service.domain.review.dto.response.ReviewGetKeywordCountResponse;
-import com.trendist.post_service.domain.review.dto.response.ReviewGetTypeCountResponse;
-import com.trendist.post_service.domain.review.dto.response.ReviewGetUserResponse;
 import com.trendist.post_service.domain.review.dto.response.ReviewGetResponse;
 import com.trendist.post_service.domain.review.dto.response.ReviewLikeResponse;
 import com.trendist.post_service.domain.review.dto.response.ReviewUpdateResponse;
@@ -89,64 +85,6 @@ public class ReviewController {
 	@GetMapping("/{reviewId}")
 	public ApiResponse<ReviewGetResponse> getReview(@PathVariable(name = "reviewId") UUID reviewId) {
 		return ApiResponse.onSuccess(reviewService.getReview(reviewId));
-	}
-
-	@Operation(
-		summary = "내가 쓴 리뷰 게시판 게시물 조회",
-		description = "현재 로그인한 사용자가 리뷰 게시판에 자신이 생성한 게시물들을 조회합니다.(본인 프로필용)"
-	)
-	@GetMapping("/profile/mine")
-	public ApiResponse<Page<ReviewGetUserResponse>> getMyReviews(@RequestParam(defaultValue = "0") int page) {
-		return ApiResponse.onSuccess(reviewService.getMyReviews(page));
-	}
-
-	@Operation(
-		summary = " 특정 사용자가 쓴 리뷰 게시물 조회",
-		description = "특정 사용자가 리뷰 게시판에 본인이 생성한 게시물들을 조회합니다.(특정 사용자 프로필용)"
-	)
-	@GetMapping("/profile/{userId}")
-	public ApiResponse<Page<ReviewGetUserResponse>> getUserReviews(
-		@RequestParam(defaultValue = "0") int page,
-		@PathVariable(name = "userId") UUID userId) {
-		return ApiResponse.onSuccess(reviewService.getUserReviews(page, userId));
-	}
-
-	@Operation(
-		summary = "활동 종류별 자신이 진행한 활동 통계 조회",
-		description = "활동 종류별로 자신이 진행한 활동들이 총 몇개인지 통계를 조회합니다."
-	)
-	@GetMapping("/mine/type/count")
-	public ApiResponse<List<ReviewGetTypeCountResponse>> countMyReviewsByType() {
-		return ApiResponse.onSuccess(reviewService.countMyReviewsByType());
-	}
-
-	@Operation(
-		summary = "활동 종류별 특정 사용자가 진행한 활동 통계 조회",
-		description = "활동 종류별로 특정 사용자가 진행한 활동들이 총 몇개인지 통계를 조회합니다."
-	)
-	@GetMapping("/{userId}/type/count")
-	public ApiResponse<List<ReviewGetTypeCountResponse>> countUserReviewsByType(
-		@PathVariable(name = "userId") UUID userId) {
-		return ApiResponse.onSuccess(reviewService.countUserReviewsByType(userId));
-	}
-
-	@Operation(
-		summary = "키워드별 자신이 진행한 활동 통계 조회",
-		description = "키워드별로 자신이 진행한 활동들이 총 몇개인지 통계를 조회합니다."
-	)
-	@GetMapping("/mine/keyword/count")
-	public ApiResponse<List<ReviewGetKeywordCountResponse>> countMyReviewsByKeyword() {
-		return ApiResponse.onSuccess(reviewService.countMyReviewsByKeyword());
-	}
-
-	@Operation(
-		summary = "키워드별 특정 사용자가 진행한 활동 통계 조회",
-		description = "키워드별로 특정 사용자가 진행한 활동들이 총 몇개인지 통계를 조회합니다."
-	)
-	@GetMapping("/{userId}/keyword/count")
-	public ApiResponse<List<ReviewGetKeywordCountResponse>> countUserReviewsByKeyword(
-		@PathVariable(name = "userId") UUID userId) {
-		return ApiResponse.onSuccess(reviewService.countUserReviewsByKeyword(userId));
 	}
 
 	@Operation(

--- a/src/main/java/com/trendist/post_service/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/trendist/post_service/domain/review/controller/ReviewController.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.trendist.post_service.domain.review.domain.ActivityType;
 import com.trendist.post_service.domain.review.domain.Keyword;
+import com.trendist.post_service.domain.review.domain.ReviewSort;
 import com.trendist.post_service.domain.review.dto.request.ReviewCreateRequest;
 import com.trendist.post_service.domain.review.dto.request.ReviewUpdateRequest;
 import com.trendist.post_service.domain.review.dto.response.ReviewCreateResponse;
@@ -68,43 +69,17 @@ public class ReviewController {
 	}
 
 	@Operation(
-		summary = "리뷰 게시판 전체 게시물 조회",
-		description = "리뷰 게시판에 전체 게시물을 조회합니다."
+		summary = "리뷰 게시판 조회",
+		description = "리뷰 게시판의 게시물을 특정 조건에 따라 조회합니다."
 	)
 	@GetMapping
-	public ApiResponse<Page<ReviewGetAllResponse>> getAllReviews(@RequestParam(defaultValue = "0") int page) {
-		return ApiResponse.onSuccess(reviewService.getAllReviews(page));
-	}
-
-	@Operation(
-		summary = "리뷰 게시판 전체 게시물 좋아요순 조회",
-		description = "리뷰 게시판에 전체 게시물을 좋아요순으로 조회합니다."
-	)
-	@GetMapping("/like")
-	public ApiResponse<Page<ReviewGetAllResponse>> getAllReviewsByLikeCunt(@RequestParam(defaultValue = "0") int page) {
-		return ApiResponse.onSuccess(reviewService.getAllReviewsByLikeCount(page));
-	}
-
-	@Operation(
-		summary = "리뷰 게시판 특정 키워드별 조회",
-		description = "리뷰 게시판 특정 키워드에 해당하는 리뷰를 조회합니다."
-	)
-	@GetMapping("/keyword/{keyword}")
-	public ApiResponse<Page<ReviewGetAllResponse>> getAllReviewsByKeyword(
+	public ApiResponse<Page<ReviewGetAllResponse>> getReviews(
 		@RequestParam(defaultValue = "0") int page,
-		@PathVariable(name = "keyword") Keyword keyword) {
-		return ApiResponse.onSuccess(reviewService.getAllReviewsByKeyword(keyword, page));
-	}
-
-	@Operation(
-		summary = "리뷰 게시판 특정 활동 종류별 조회",
-		description = "리뷰 게시판 특정 종류에 해당하는 리뷰를 조회합니다."
-	)
-	@GetMapping("/type/{activityType}")
-	public ApiResponse<Page<ReviewGetAllResponse>> getAllReviewsByActivityType(
-		@RequestParam(defaultValue = "0") int page,
-		@PathVariable(name = "activityType") ActivityType activityType) {
-		return ApiResponse.onSuccess(reviewService.getAllReviewsByActivityType(activityType, page));
+		@RequestParam(required = false) Keyword keyword,
+		@RequestParam(required = false) ActivityType activityType,
+		@RequestParam(name = "sort", defaultValue = "RECENT") ReviewSort sort
+	) {
+		return ApiResponse.onSuccess(reviewService.getReviews(keyword, activityType, sort, page));
 	}
 
 	@Operation(

--- a/src/main/java/com/trendist/post_service/domain/review/controller/ReviewProfileController.java
+++ b/src/main/java/com/trendist/post_service/domain/review/controller/ReviewProfileController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.trendist.post_service.domain.review.dto.response.ReviewGetKeywordCountResponse;
 import com.trendist.post_service.domain.review.dto.response.ReviewGetTypeCountResponse;
 import com.trendist.post_service.domain.review.dto.response.ReviewGetUserResponse;
-import com.trendist.post_service.domain.review.service.ReviewService;
+import com.trendist.post_service.domain.review.service.ReviewProfileService;
 import com.trendist.post_service.global.response.ApiResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -23,7 +23,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @RequestMapping("/profile")
 public class ReviewProfileController {
-	private final ReviewService reviewService;
+	private final ReviewProfileService reviewProfileService;
 
 	@Operation(
 		summary = "내가 쓴 리뷰 게시판 게시물 조회",
@@ -31,7 +31,7 @@ public class ReviewProfileController {
 	)
 	@GetMapping("/mine")
 	public ApiResponse<Page<ReviewGetUserResponse>> getMyReviews(@RequestParam(defaultValue = "0") int page) {
-		return ApiResponse.onSuccess(reviewService.getMyReviews(page));
+		return ApiResponse.onSuccess(reviewProfileService.getMyReviews(page));
 	}
 
 	@Operation(
@@ -42,7 +42,7 @@ public class ReviewProfileController {
 	public ApiResponse<Page<ReviewGetUserResponse>> getUserReviews(
 		@RequestParam(defaultValue = "0") int page,
 		@PathVariable(name = "userId") UUID userId) {
-		return ApiResponse.onSuccess(reviewService.getUserReviews(page, userId));
+		return ApiResponse.onSuccess(reviewProfileService.getUserReviews(page, userId));
 	}
 
 	@Operation(
@@ -51,7 +51,7 @@ public class ReviewProfileController {
 	)
 	@GetMapping("/mine/type/count")
 	public ApiResponse<List<ReviewGetTypeCountResponse>> countMyReviewsByType() {
-		return ApiResponse.onSuccess(reviewService.countMyReviewsByType());
+		return ApiResponse.onSuccess(reviewProfileService.countMyReviewsByType());
 	}
 
 	@Operation(
@@ -61,7 +61,7 @@ public class ReviewProfileController {
 	@GetMapping("/{userId}/type/count")
 	public ApiResponse<List<ReviewGetTypeCountResponse>> countUserReviewsByType(
 		@PathVariable(name = "userId") UUID userId) {
-		return ApiResponse.onSuccess(reviewService.countUserReviewsByType(userId));
+		return ApiResponse.onSuccess(reviewProfileService.countUserReviewsByType(userId));
 	}
 
 	@Operation(
@@ -70,7 +70,7 @@ public class ReviewProfileController {
 	)
 	@GetMapping("/mine/keyword/count")
 	public ApiResponse<List<ReviewGetKeywordCountResponse>> countMyReviewsByKeyword() {
-		return ApiResponse.onSuccess(reviewService.countMyReviewsByKeyword());
+		return ApiResponse.onSuccess(reviewProfileService.countMyReviewsByKeyword());
 	}
 
 	@Operation(
@@ -80,6 +80,6 @@ public class ReviewProfileController {
 	@GetMapping("/{userId}/keyword/count")
 	public ApiResponse<List<ReviewGetKeywordCountResponse>> countUserReviewsByKeyword(
 		@PathVariable(name = "userId") UUID userId) {
-		return ApiResponse.onSuccess(reviewService.countUserReviewsByKeyword(userId));
+		return ApiResponse.onSuccess(reviewProfileService.countUserReviewsByKeyword(userId));
 	}
 }

--- a/src/main/java/com/trendist/post_service/domain/review/controller/ReviewProfileController.java
+++ b/src/main/java/com/trendist/post_service/domain/review/controller/ReviewProfileController.java
@@ -29,7 +29,7 @@ public class ReviewProfileController {
 		summary = "내가 쓴 리뷰 게시판 게시물 조회",
 		description = "현재 로그인한 사용자가 리뷰 게시판에 자신이 생성한 게시물들을 조회합니다.(본인 프로필용)"
 	)
-	@GetMapping("/mine")
+	@GetMapping("/reviews/mine")
 	public ApiResponse<Page<ReviewGetUserResponse>> getMyReviews(@RequestParam(defaultValue = "0") int page) {
 		return ApiResponse.onSuccess(reviewProfileService.getMyReviews(page));
 	}
@@ -38,7 +38,7 @@ public class ReviewProfileController {
 		summary = "특정 사용자가 쓴 리뷰 게시물 조회",
 		description = "특정 사용자가 리뷰 게시판에 본인이 생성한 게시물들을 조회합니다.(특정 사용자 프로필용)"
 	)
-	@GetMapping("/{userId}")
+	@GetMapping("/reviews/{userId}")
 	public ApiResponse<Page<ReviewGetUserResponse>> getUserReviews(
 		@RequestParam(defaultValue = "0") int page,
 		@PathVariable(name = "userId") UUID userId) {
@@ -49,7 +49,7 @@ public class ReviewProfileController {
 		summary = "활동 종류별 자신이 진행한 활동 통계 조회",
 		description = "활동 종류별로 자신이 진행한 활동들이 총 몇개인지 통계를 조회합니다."
 	)
-	@GetMapping("/mine/type/count")
+	@GetMapping("/reviews/mine/type/count")
 	public ApiResponse<List<ReviewGetTypeCountResponse>> countMyReviewsByType() {
 		return ApiResponse.onSuccess(reviewProfileService.countMyReviewsByType());
 	}
@@ -58,7 +58,7 @@ public class ReviewProfileController {
 		summary = "활동 종류별 특정 사용자가 진행한 활동 통계 조회",
 		description = "활동 종류별로 특정 사용자가 진행한 활동들이 총 몇개인지 통계를 조회합니다."
 	)
-	@GetMapping("/{userId}/type/count")
+	@GetMapping("/reviews/{userId}/type/count")
 	public ApiResponse<List<ReviewGetTypeCountResponse>> countUserReviewsByType(
 		@PathVariable(name = "userId") UUID userId) {
 		return ApiResponse.onSuccess(reviewProfileService.countUserReviewsByType(userId));
@@ -68,7 +68,7 @@ public class ReviewProfileController {
 		summary = "키워드별 자신이 진행한 활동 통계 조회",
 		description = "키워드별로 자신이 진행한 활동들이 총 몇개인지 통계를 조회합니다."
 	)
-	@GetMapping("/mine/keyword/count")
+	@GetMapping("/reviews/mine/keyword/count")
 	public ApiResponse<List<ReviewGetKeywordCountResponse>> countMyReviewsByKeyword() {
 		return ApiResponse.onSuccess(reviewProfileService.countMyReviewsByKeyword());
 	}
@@ -77,7 +77,7 @@ public class ReviewProfileController {
 		summary = "키워드별 특정 사용자가 진행한 활동 통계 조회",
 		description = "키워드별로 특정 사용자가 진행한 활동들이 총 몇개인지 통계를 조회합니다."
 	)
-	@GetMapping("/{userId}/keyword/count")
+	@GetMapping("/reviews/{userId}/keyword/count")
 	public ApiResponse<List<ReviewGetKeywordCountResponse>> countUserReviewsByKeyword(
 		@PathVariable(name = "userId") UUID userId) {
 		return ApiResponse.onSuccess(reviewProfileService.countUserReviewsByKeyword(userId));

--- a/src/main/java/com/trendist/post_service/domain/review/controller/ReviewProfileController.java
+++ b/src/main/java/com/trendist/post_service/domain/review/controller/ReviewProfileController.java
@@ -1,0 +1,85 @@
+package com.trendist.post_service.domain.review.controller;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.data.domain.Page;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.trendist.post_service.domain.review.dto.response.ReviewGetKeywordCountResponse;
+import com.trendist.post_service.domain.review.dto.response.ReviewGetTypeCountResponse;
+import com.trendist.post_service.domain.review.dto.response.ReviewGetUserResponse;
+import com.trendist.post_service.domain.review.service.ReviewService;
+import com.trendist.post_service.global.response.ApiResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/profile")
+public class ReviewProfileController {
+	private final ReviewService reviewService;
+
+	@Operation(
+		summary = "내가 쓴 리뷰 게시판 게시물 조회",
+		description = "현재 로그인한 사용자가 리뷰 게시판에 자신이 생성한 게시물들을 조회합니다.(본인 프로필용)"
+	)
+	@GetMapping("/mine")
+	public ApiResponse<Page<ReviewGetUserResponse>> getMyReviews(@RequestParam(defaultValue = "0") int page) {
+		return ApiResponse.onSuccess(reviewService.getMyReviews(page));
+	}
+
+	@Operation(
+		summary = "특정 사용자가 쓴 리뷰 게시물 조회",
+		description = "특정 사용자가 리뷰 게시판에 본인이 생성한 게시물들을 조회합니다.(특정 사용자 프로필용)"
+	)
+	@GetMapping("/{userId}")
+	public ApiResponse<Page<ReviewGetUserResponse>> getUserReviews(
+		@RequestParam(defaultValue = "0") int page,
+		@PathVariable(name = "userId") UUID userId) {
+		return ApiResponse.onSuccess(reviewService.getUserReviews(page, userId));
+	}
+
+	@Operation(
+		summary = "활동 종류별 자신이 진행한 활동 통계 조회",
+		description = "활동 종류별로 자신이 진행한 활동들이 총 몇개인지 통계를 조회합니다."
+	)
+	@GetMapping("/mine/type/count")
+	public ApiResponse<List<ReviewGetTypeCountResponse>> countMyReviewsByType() {
+		return ApiResponse.onSuccess(reviewService.countMyReviewsByType());
+	}
+
+	@Operation(
+		summary = "활동 종류별 특정 사용자가 진행한 활동 통계 조회",
+		description = "활동 종류별로 특정 사용자가 진행한 활동들이 총 몇개인지 통계를 조회합니다."
+	)
+	@GetMapping("/{userId}/type/count")
+	public ApiResponse<List<ReviewGetTypeCountResponse>> countUserReviewsByType(
+		@PathVariable(name = "userId") UUID userId) {
+		return ApiResponse.onSuccess(reviewService.countUserReviewsByType(userId));
+	}
+
+	@Operation(
+		summary = "키워드별 자신이 진행한 활동 통계 조회",
+		description = "키워드별로 자신이 진행한 활동들이 총 몇개인지 통계를 조회합니다."
+	)
+	@GetMapping("/mine/keyword/count")
+	public ApiResponse<List<ReviewGetKeywordCountResponse>> countMyReviewsByKeyword() {
+		return ApiResponse.onSuccess(reviewService.countMyReviewsByKeyword());
+	}
+
+	@Operation(
+		summary = "키워드별 특정 사용자가 진행한 활동 통계 조회",
+		description = "키워드별로 특정 사용자가 진행한 활동들이 총 몇개인지 통계를 조회합니다."
+	)
+	@GetMapping("/{userId}/keyword/count")
+	public ApiResponse<List<ReviewGetKeywordCountResponse>> countUserReviewsByKeyword(
+		@PathVariable(name = "userId") UUID userId) {
+		return ApiResponse.onSuccess(reviewService.countUserReviewsByKeyword(userId));
+	}
+}

--- a/src/main/java/com/trendist/post_service/domain/review/domain/ReviewSort.java
+++ b/src/main/java/com/trendist/post_service/domain/review/domain/ReviewSort.java
@@ -1,0 +1,6 @@
+package com.trendist.post_service.domain.review.domain;
+
+public enum ReviewSort {
+	RECENT,
+	LIKES
+}

--- a/src/main/java/com/trendist/post_service/domain/review/dto/response/ReviewGetUserResponse.java
+++ b/src/main/java/com/trendist/post_service/domain/review/dto/response/ReviewGetUserResponse.java
@@ -8,13 +8,13 @@ import com.trendist.post_service.domain.review.domain.Review;
 import lombok.Builder;
 
 @Builder
-public record ReviewGetMineResponse(
+public record ReviewGetUserResponse(
 	UUID id,
 	String title,
 	LocalDateTime updatedAt
 ) {
-	public static ReviewGetMineResponse from(Review review) {
-		return ReviewGetMineResponse.builder()
+	public static ReviewGetUserResponse from(Review review) {
+		return ReviewGetUserResponse.builder()
 			.id(review.getId())
 			.title(review.getTitle())
 			.updatedAt(review.getUpdatedAt())

--- a/src/main/java/com/trendist/post_service/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/trendist/post_service/domain/review/repository/ReviewRepository.java
@@ -22,11 +22,14 @@ public interface ReviewRepository extends JpaRepository<Review, UUID> {
 
 	Page<Review> findByUserIdAndDeletedFalse(UUID id, Pageable pageable);
 
-	Page<Review> findAllByDeletedFalseOrderByLikeCountDesc(Pageable pageable);
-
 	Page<Review> findAllByKeywordAndDeletedFalse(Keyword keyword, Pageable pageable);
 
 	Page<Review> findAllByActivityTypeAndDeletedFalse(ActivityType activityType, Pageable pageable);
+
+	Page<Review> findAllByKeywordAndActivityTypeAndDeletedFalse(
+		Keyword keyword,
+		ActivityType activityType,
+		Pageable pageable);
 
 	List<Review> findAllByUserIdAndDeletedFalse(UUID userId);
 

--- a/src/main/java/com/trendist/post_service/domain/review/service/ReviewProfileService.java
+++ b/src/main/java/com/trendist/post_service/domain/review/service/ReviewProfileService.java
@@ -1,0 +1,96 @@
+package com.trendist.post_service.domain.review.service;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+
+import com.trendist.post_service.domain.review.domain.ActivityType;
+import com.trendist.post_service.domain.review.domain.Keyword;
+import com.trendist.post_service.domain.review.domain.Review;
+import com.trendist.post_service.domain.review.dto.response.ReviewGetKeywordCountResponse;
+import com.trendist.post_service.domain.review.dto.response.ReviewGetTypeCountResponse;
+import com.trendist.post_service.domain.review.dto.response.ReviewGetUserResponse;
+import com.trendist.post_service.domain.review.repository.ReviewRepository;
+import com.trendist.post_service.global.feign.user.client.UserServiceClient;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ReviewProfileService {
+	private final ReviewRepository reviewRepository;
+	private final UserServiceClient userServiceClient;
+
+	public Page<ReviewGetUserResponse> getMyReviews(int page) {
+		UUID userId = userServiceClient.getMyProfile("").getResult().id();
+		Pageable pageable = PageRequest.of(page, 10, Sort.by("updatedAt").descending());
+
+		return reviewRepository.findByUserIdAndDeletedFalse(userId, pageable)
+			.map(ReviewGetUserResponse::from);
+	}
+
+	public Page<ReviewGetUserResponse> getUserReviews(int page, UUID userId) {
+		Pageable pageable = PageRequest.of(page, 10, Sort.by("updatedAt").descending());
+
+		return reviewRepository.findByUserIdAndDeletedFalse(userId, pageable)
+			.map(ReviewGetUserResponse::from);
+	}
+
+	public List<ReviewGetTypeCountResponse> countMyReviewsByType() {
+		UUID userId = userServiceClient.getMyProfile("").getResult().id();
+
+		return countByType(userId);
+	}
+
+	public List<ReviewGetTypeCountResponse> countUserReviewsByType(UUID userId) {
+		return countByType(userId);
+	}
+
+	public List<ReviewGetKeywordCountResponse> countMyReviewsByKeyword() {
+		UUID userId = userServiceClient.getMyProfile("").getResult().id();
+
+		return countByKeyword(userId);
+	}
+
+	public List<ReviewGetKeywordCountResponse> countUserReviewsByKeyword(UUID userId) {
+		return countByKeyword(userId);
+	}
+
+	private List<ReviewGetTypeCountResponse> countByType(UUID userId) {
+		Map<ActivityType, Long> counts = reviewRepository.findAllByUserIdAndDeletedFalse(userId)
+			.stream()
+			.collect(Collectors.groupingBy(Review::getActivityType, Collectors.counting()));
+
+		return Arrays.stream(ActivityType.values())
+			.map(type -> ReviewGetTypeCountResponse.builder()
+				.userId(userId)
+				.activityType(type)
+				.count(counts.getOrDefault(type, 0L))
+				.build()
+			)
+			.toList();
+	}
+
+	private List<ReviewGetKeywordCountResponse> countByKeyword(UUID userId) {
+		Map<Keyword, Long> counts = reviewRepository.findAllByUserIdAndDeletedFalse(userId)
+			.stream()
+			.collect(Collectors.groupingBy(Review::getKeyword, Collectors.counting()));
+
+		return Arrays.stream(Keyword.values())
+			.map(keyword -> ReviewGetKeywordCountResponse.builder()
+				.userId(userId)
+				.keyword(keyword)
+				.count(counts.getOrDefault(keyword, 0L))
+				.build()
+			)
+			.toList();
+	}
+}

--- a/src/main/java/com/trendist/post_service/domain/review/service/ReviewService.java
+++ b/src/main/java/com/trendist/post_service/domain/review/service/ReviewService.java
@@ -25,7 +25,7 @@ import com.trendist.post_service.domain.review.dto.response.ReviewDeleteResponse
 import com.trendist.post_service.domain.review.dto.response.ReviewGetAllResponse;
 import com.trendist.post_service.domain.review.dto.response.ReviewGetTypeCountResponse;
 import com.trendist.post_service.domain.review.dto.response.ReviewGetKeywordCountResponse;
-import com.trendist.post_service.domain.review.dto.response.ReviewGetMineResponse;
+import com.trendist.post_service.domain.review.dto.response.ReviewGetUserResponse;
 import com.trendist.post_service.domain.review.dto.response.ReviewGetResponse;
 import com.trendist.post_service.domain.review.dto.response.ReviewLikeResponse;
 import com.trendist.post_service.domain.review.dto.response.ReviewUpdateResponse;
@@ -151,12 +151,19 @@ public class ReviewService {
 		return ReviewGetResponse.of(review, profileUrl);
 	}
 
-	public Page<ReviewGetMineResponse> getMyReviews(int page) {
+	public Page<ReviewGetUserResponse> getMyReviews(int page) {
 		UUID userId = userServiceClient.getMyProfile("").getResult().id();
 		Pageable pageable = PageRequest.of(page, 10, Sort.by("updatedAt").descending());
 
 		return reviewRepository.findByUserIdAndDeletedFalse(userId, pageable)
-			.map(ReviewGetMineResponse::from);
+			.map(ReviewGetUserResponse::from);
+	}
+
+	public Page<ReviewGetUserResponse> getUserReviews(int page, UUID userId) {
+		Pageable pageable = PageRequest.of(page, 10, Sort.by("updatedAt").descending());
+
+		return reviewRepository.findByUserIdAndDeletedFalse(userId, pageable)
+			.map(ReviewGetUserResponse::from);
 	}
 
 	@Transactional

--- a/src/main/java/com/trendist/post_service/domain/review/service/ReviewService.java
+++ b/src/main/java/com/trendist/post_service/domain/review/service/ReviewService.java
@@ -1,10 +1,6 @@
 package com.trendist.post_service.domain.review.service;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -23,9 +19,6 @@ import com.trendist.post_service.domain.review.dto.request.ReviewUpdateRequest;
 import com.trendist.post_service.domain.review.dto.response.ReviewCreateResponse;
 import com.trendist.post_service.domain.review.dto.response.ReviewDeleteResponse;
 import com.trendist.post_service.domain.review.dto.response.ReviewGetAllResponse;
-import com.trendist.post_service.domain.review.dto.response.ReviewGetTypeCountResponse;
-import com.trendist.post_service.domain.review.dto.response.ReviewGetKeywordCountResponse;
-import com.trendist.post_service.domain.review.dto.response.ReviewGetUserResponse;
 import com.trendist.post_service.domain.review.dto.response.ReviewGetResponse;
 import com.trendist.post_service.domain.review.dto.response.ReviewLikeResponse;
 import com.trendist.post_service.domain.review.dto.response.ReviewUpdateResponse;
@@ -151,21 +144,6 @@ public class ReviewService {
 		return ReviewGetResponse.of(review, profileUrl);
 	}
 
-	public Page<ReviewGetUserResponse> getMyReviews(int page) {
-		UUID userId = userServiceClient.getMyProfile("").getResult().id();
-		Pageable pageable = PageRequest.of(page, 10, Sort.by("updatedAt").descending());
-
-		return reviewRepository.findByUserIdAndDeletedFalse(userId, pageable)
-			.map(ReviewGetUserResponse::from);
-	}
-
-	public Page<ReviewGetUserResponse> getUserReviews(int page, UUID userId) {
-		Pageable pageable = PageRequest.of(page, 10, Sort.by("updatedAt").descending());
-
-		return reviewRepository.findByUserIdAndDeletedFalse(userId, pageable)
-			.map(ReviewGetUserResponse::from);
-	}
-
 	@Transactional
 	public ReviewLikeResponse likeReview(UUID reviewId) {
 		UUID userId = userServiceClient.getMyProfile("").getResult().id();
@@ -190,55 +168,5 @@ public class ReviewService {
 		}
 
 		return ReviewLikeResponse.of(reviewLike, like);
-	}
-
-	public List<ReviewGetTypeCountResponse> countMyReviewsByType() {
-		UUID userId = userServiceClient.getMyProfile("").getResult().id();
-
-		return countByType(userId);
-	}
-
-	public List<ReviewGetTypeCountResponse> countUserReviewsByType(UUID userId) {
-		return countByType(userId);
-	}
-
-	public List<ReviewGetKeywordCountResponse> countMyReviewsByKeyword() {
-		UUID userId = userServiceClient.getMyProfile("").getResult().id();
-
-		return countByKeyword(userId);
-	}
-
-	public List<ReviewGetKeywordCountResponse> countUserReviewsByKeyword(UUID userId) {
-		return countByKeyword(userId);
-	}
-
-	private List<ReviewGetTypeCountResponse> countByType(UUID userId) {
-		Map<ActivityType, Long> counts = reviewRepository.findAllByUserIdAndDeletedFalse(userId)
-			.stream()
-			.collect(Collectors.groupingBy(Review::getActivityType, Collectors.counting()));
-
-		return Arrays.stream(ActivityType.values())
-			.map(type -> ReviewGetTypeCountResponse.builder()
-				.userId(userId)
-				.activityType(type)
-				.count(counts.getOrDefault(type, 0L))
-				.build()
-			)
-			.toList();
-	}
-
-	private List<ReviewGetKeywordCountResponse> countByKeyword(UUID userId) {
-		Map<Keyword, Long> counts = reviewRepository.findAllByUserIdAndDeletedFalse(userId)
-			.stream()
-			.collect(Collectors.groupingBy(Review::getKeyword, Collectors.counting()));
-
-		return Arrays.stream(Keyword.values())
-			.map(keyword -> ReviewGetKeywordCountResponse.builder()
-				.userId(userId)
-				.keyword(keyword)
-				.count(counts.getOrDefault(keyword, 0L))
-				.build()
-			)
-			.toList();
 	}
 }


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [x] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용
**1. 리뷰 조회 기능 중 전체, 좋아요순, 활동 종류별, 키워드별 조회 기능을 하나로 합쳤습니다. 따라서 원하는 조건에 따라 리뷰를 조회할 수 있습니다.**
<img width="1289" alt="image" src="https://github.com/user-attachments/assets/c5ecf69d-2f0c-4ccc-93f5-bd3b0ce77dca" />
<img width="1301" alt="image" src="https://github.com/user-attachments/assets/d5a1e255-6231-4a56-942b-6b544980584b" />
<img width="1300" alt="image" src="https://github.com/user-attachments/assets/51e7ad60-84a7-4133-8699-73aa765531f6" />

**2. 특정 사용자가 작성한 리뷰를 조회하는 기능을 구현하였습니다.**
<img width="1301" alt="image" src="https://github.com/user-attachments/assets/aec6e252-3eeb-4aac-a323-38e382c8a12c" />

**3. 특정 사용자가 작성한 자유 게시물을 조회하는 기능을 구현하였습니다.**
<img width="1307" alt="image" src="https://github.com/user-attachments/assets/ec24960a-f46a-4602-a50e-124ade3a7b05" />

---

## 🔗 관련 이슈
- close #15 

---

## 💡 추가 사항
**현재 service에 너무 많은 로직이 구현되어있다 판단하여 프로필에 표시될 내용들에 대한 서비스와 컨트롤러를 분리하였습니다.**
