### PR TITLE
feat: cdc 아키텍쳐를 통한 검색 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+    implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
     implementation platform("io.awspring.cloud:spring-cloud-aws-dependencies:3.3.0")
     implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3'
     implementation 'com.amazonaws:aws-java-sdk-s3:1.12.638'

--- a/src/main/java/com/trendist/post_service/domain/post/controller/PostController.java
+++ b/src/main/java/com/trendist/post_service/domain/post/controller/PostController.java
@@ -16,7 +16,7 @@ import com.trendist.post_service.domain.post.dto.request.PostUpdateRequest;
 import com.trendist.post_service.domain.post.dto.response.PostDeleteResponse;
 import com.trendist.post_service.domain.post.dto.response.PostGetAllResponse;
 import com.trendist.post_service.domain.post.dto.response.PostGetResponse;
-import com.trendist.post_service.domain.post.dto.response.PostGetSearchResponse;
+import com.trendist.post_service.domain.post.dto.response.PostSearchResponse;
 import com.trendist.post_service.domain.post.dto.response.PostLikeResponse;
 import com.trendist.post_service.domain.post.dto.response.PostUpdateResponse;
 import com.trendist.post_service.global.response.ApiResponse;
@@ -103,7 +103,7 @@ public class PostController {
 		description = "사용자가 자유 게시판에 특정 단어를 입력하여 해당하는 게시물을 검색합니다"
 	)
 	@GetMapping("/search")
-	public ApiResponse<Page<PostGetSearchResponse>> searchPosts(
+	public ApiResponse<Page<PostSearchResponse>> searchPosts(
 		@RequestParam String keyword,
 		@RequestParam(defaultValue = "0") int page
 	) {

--- a/src/main/java/com/trendist/post_service/domain/post/controller/PostController.java
+++ b/src/main/java/com/trendist/post_service/domain/post/controller/PostController.java
@@ -16,6 +16,7 @@ import com.trendist.post_service.domain.post.dto.request.PostUpdateRequest;
 import com.trendist.post_service.domain.post.dto.response.PostDeleteResponse;
 import com.trendist.post_service.domain.post.dto.response.PostGetAllResponse;
 import com.trendist.post_service.domain.post.dto.response.PostGetResponse;
+import com.trendist.post_service.domain.post.dto.response.PostGetSearchResponse;
 import com.trendist.post_service.domain.post.dto.response.PostLikeResponse;
 import com.trendist.post_service.domain.post.dto.response.PostUpdateResponse;
 import com.trendist.post_service.global.response.ApiResponse;
@@ -95,5 +96,17 @@ public class PostController {
 	@PostMapping("/{postId}/like")
 	public ApiResponse<PostLikeResponse> likePost(@PathVariable(name = "postId") UUID postId) {
 		return ApiResponse.onSuccess(postService.likePost(postId));
+	}
+
+	@Operation(
+		summary = "자유 게시판 검색",
+		description = "사용자가 자유 게시판에 특정 단어를 입력하여 해당하는 게시물을 검색합니다"
+	)
+	@GetMapping("/search")
+	public ApiResponse<Page<PostGetSearchResponse>> searchPosts(
+		@RequestParam String keyword,
+		@RequestParam(defaultValue = "0") int page
+	) {
+		return ApiResponse.onSuccess(postService.searchPosts(keyword, page));
 	}
 }

--- a/src/main/java/com/trendist/post_service/domain/post/controller/PostProfileController.java
+++ b/src/main/java/com/trendist/post_service/domain/post/controller/PostProfileController.java
@@ -18,7 +18,7 @@ import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/profile")
+@RequestMapping("/profile/posts")
 public class PostProfileController {
 	private final PostProfileService postProfileService;
 
@@ -26,7 +26,7 @@ public class PostProfileController {
 		summary = "내가 쓴 자유 게시판 게시물 조회",
 		description = "현재 로그인한 사용자가 자유 게시판에 자신이 생성한 게시물들을 조회합니다."
 	)
-	@GetMapping("/posts/mine")
+	@GetMapping("/mine")
 	public ApiResponse<Page<PostGetUserResponse>> getMyPosts(@RequestParam(defaultValue = "0") int page) {
 		return ApiResponse.onSuccess(postProfileService.getMyPosts(page));
 	}
@@ -35,7 +35,7 @@ public class PostProfileController {
 		summary = "특정 사용자가 쓴 자유 게시판 게시물 조회",
 		description = "특정 사용자가 자유 게시판에 본인이 생성한 게시물들을 조회합니다."
 	)
-	@GetMapping("/posts/{userId}")
+	@GetMapping("/{userId}")
 	public ApiResponse<Page<PostGetUserResponse>> getUserPosts(
 		@RequestParam(defaultValue = "0") int page,
 		@PathVariable(name = "userId") UUID userId) {

--- a/src/main/java/com/trendist/post_service/domain/post/domain/PostDocument.java
+++ b/src/main/java/com/trendist/post_service/domain/post/domain/PostDocument.java
@@ -1,0 +1,36 @@
+package com.trendist.post_service.domain.post.domain;
+
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
+import org.springframework.data.elasticsearch.annotations.InnerField;
+import org.springframework.data.elasticsearch.annotations.MultiField;
+
+import jakarta.persistence.Id;
+import lombok.Builder;
+import lombok.Getter;
+
+@Document(indexName = "mysql-trendist.trendist.posts")
+@Builder
+@Getter
+public class PostDocument {
+	@Id
+	private String id;
+
+	@MultiField(
+		mainField = @Field(name = "post_title", type = FieldType.Text, analyzer = "standard"),
+		otherFields = {
+			@InnerField(suffix = "keyword", type = FieldType.Keyword)
+		}
+	)
+	private String title;
+
+	@Field(name = "nickname", type = FieldType.Keyword)
+	private String nickname;
+
+	@Field(name = "post_like_count", type = FieldType.Integer)
+	private Integer likeCount;
+
+	@Field(name = "created_at", type = FieldType.Keyword)
+	private String createdAt;
+}

--- a/src/main/java/com/trendist/post_service/domain/post/dto/response/PostGetSearchResponse.java
+++ b/src/main/java/com/trendist/post_service/domain/post/dto/response/PostGetSearchResponse.java
@@ -1,0 +1,32 @@
+package com.trendist.post_service.domain.post.dto.response;
+
+import java.nio.ByteBuffer;
+import java.util.Base64;
+import java.util.UUID;
+
+import com.trendist.post_service.domain.post.domain.PostDocument;
+
+import lombok.Builder;
+
+@Builder
+public record PostGetSearchResponse(
+	UUID id,
+	String title,
+	String nickname,
+	Integer likeCount,
+	String createdAt
+) {
+	public static PostGetSearchResponse from(PostDocument postDocument) {
+		byte[] bytes = Base64.getDecoder().decode(postDocument.getId());
+		ByteBuffer bb = ByteBuffer.wrap(bytes);
+		UUID uuid = new UUID(bb.getLong(), bb.getLong());
+
+		return PostGetSearchResponse.builder()
+			.id(uuid)
+			.title(postDocument.getTitle())
+			.nickname(postDocument.getNickname())
+			.likeCount(postDocument.getLikeCount())
+			.createdAt(postDocument.getCreatedAt())
+			.build();
+	}
+}

--- a/src/main/java/com/trendist/post_service/domain/post/dto/response/PostSearchResponse.java
+++ b/src/main/java/com/trendist/post_service/domain/post/dto/response/PostSearchResponse.java
@@ -9,19 +9,19 @@ import com.trendist.post_service.domain.post.domain.PostDocument;
 import lombok.Builder;
 
 @Builder
-public record PostGetSearchResponse(
+public record PostSearchResponse(
 	UUID id,
 	String title,
 	String nickname,
 	Integer likeCount,
 	String createdAt
 ) {
-	public static PostGetSearchResponse from(PostDocument postDocument) {
+	public static PostSearchResponse from(PostDocument postDocument) {
 		byte[] bytes = Base64.getDecoder().decode(postDocument.getId());
 		ByteBuffer bb = ByteBuffer.wrap(bytes);
 		UUID uuid = new UUID(bb.getLong(), bb.getLong());
 
-		return PostGetSearchResponse.builder()
+		return PostSearchResponse.builder()
 			.id(uuid)
 			.title(postDocument.getTitle())
 			.nickname(postDocument.getNickname())

--- a/src/main/java/com/trendist/post_service/domain/post/service/PostService.java
+++ b/src/main/java/com/trendist/post_service/domain/post/service/PostService.java
@@ -1,18 +1,26 @@
 package com.trendist.post_service.domain.post.service;
 
+import java.util.List;
 import java.util.UUID;
 
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.elasticsearch.client.elc.NativeQuery;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.SearchHit;
+import org.springframework.data.elasticsearch.core.SearchHits;
 import org.springframework.stereotype.Service;
 
+import com.trendist.post_service.domain.post.domain.PostDocument;
 import com.trendist.post_service.domain.post.domain.PostLike;
 import com.trendist.post_service.domain.post.dto.request.PostUpdateRequest;
 import com.trendist.post_service.domain.post.dto.response.PostDeleteResponse;
 import com.trendist.post_service.domain.post.dto.response.PostGetAllResponse;
 import com.trendist.post_service.domain.post.dto.response.PostGetResponse;
+import com.trendist.post_service.domain.post.dto.response.PostGetSearchResponse;
 import com.trendist.post_service.domain.post.dto.response.PostLikeResponse;
 import com.trendist.post_service.domain.post.dto.response.PostUpdateResponse;
 import com.trendist.post_service.domain.post.repository.PostLikeRepository;
@@ -24,6 +32,7 @@ import com.trendist.post_service.domain.post.dto.response.PostCreateResponse;
 import com.trendist.post_service.domain.post.repository.PostRepository;
 import com.trendist.post_service.global.response.status.ErrorStatus;
 
+import co.elastic.clients.elasticsearch._types.SortOrder;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 
@@ -33,6 +42,7 @@ public class PostService {
 	private final PostRepository postRepository;
 	private final PostLikeRepository postLikeRepository;
 	private final UserServiceClient userServiceClient;
+	private final ElasticsearchOperations esOps;
 
 	@Transactional
 	public PostCreateResponse createPost(PostCreateRequest postCreateRequest) {
@@ -131,5 +141,34 @@ public class PostService {
 			like = false;
 		}
 		return PostLikeResponse.of(postLike, like);
+	}
+
+	public Page<PostGetSearchResponse> searchPosts(String keyword, int page) {
+		Pageable pageable = PageRequest.of(page, 10);
+
+		NativeQuery query = NativeQuery.builder()
+			.withQuery(q -> q
+				.wildcard(w -> w
+					.field("post_title.keyword")
+					.value("*" + keyword + "*")
+				)
+			)
+			.withSort(s -> s.field(f -> f
+					.field("created_at.keyword")
+					.order(SortOrder.Desc)
+				)
+			)
+			.withPageable(pageable)
+			.build();
+
+		// 3) 검색 실행
+		SearchHits<PostDocument> hits = esOps.search(query, PostDocument.class);
+
+		List<PostGetSearchResponse> content = hits.getSearchHits().stream()
+			.map(SearchHit::getContent)
+			.map(PostGetSearchResponse::from)
+			.toList();
+
+		return new PageImpl<>(content, pageable, hits.getTotalHits());
 	}
 }

--- a/src/main/java/com/trendist/post_service/domain/post/service/PostService.java
+++ b/src/main/java/com/trendist/post_service/domain/post/service/PostService.java
@@ -20,7 +20,7 @@ import com.trendist.post_service.domain.post.dto.request.PostUpdateRequest;
 import com.trendist.post_service.domain.post.dto.response.PostDeleteResponse;
 import com.trendist.post_service.domain.post.dto.response.PostGetAllResponse;
 import com.trendist.post_service.domain.post.dto.response.PostGetResponse;
-import com.trendist.post_service.domain.post.dto.response.PostGetSearchResponse;
+import com.trendist.post_service.domain.post.dto.response.PostSearchResponse;
 import com.trendist.post_service.domain.post.dto.response.PostLikeResponse;
 import com.trendist.post_service.domain.post.dto.response.PostUpdateResponse;
 import com.trendist.post_service.domain.post.repository.PostLikeRepository;
@@ -143,7 +143,7 @@ public class PostService {
 		return PostLikeResponse.of(postLike, like);
 	}
 
-	public Page<PostGetSearchResponse> searchPosts(String keyword, int page) {
+	public Page<PostSearchResponse> searchPosts(String keyword, int page) {
 		Pageable pageable = PageRequest.of(page, 10);
 
 		NativeQuery query = NativeQuery.builder()
@@ -164,9 +164,9 @@ public class PostService {
 		// 3) 검색 실행
 		SearchHits<PostDocument> hits = esOps.search(query, PostDocument.class);
 
-		List<PostGetSearchResponse> content = hits.getSearchHits().stream()
+		List<PostSearchResponse> content = hits.getSearchHits().stream()
 			.map(SearchHit::getContent)
-			.map(PostGetSearchResponse::from)
+			.map(PostSearchResponse::from)
 			.toList();
 
 		return new PageImpl<>(content, pageable, hits.getTotalHits());

--- a/src/main/java/com/trendist/post_service/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/trendist/post_service/domain/review/controller/ReviewController.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.trendist.post_service.domain.review.domain.ActivityType;
 import com.trendist.post_service.domain.review.domain.Keyword;
 import com.trendist.post_service.domain.review.domain.ReviewSort;
+import com.trendist.post_service.domain.review.dto.request.ReviewActivityCreateRequest;
 import com.trendist.post_service.domain.review.dto.request.ReviewCreateRequest;
 import com.trendist.post_service.domain.review.dto.request.ReviewUpdateRequest;
 import com.trendist.post_service.domain.review.dto.response.ReviewCreateResponse;
@@ -43,6 +44,18 @@ public class ReviewController {
 	@PostMapping
 	public ApiResponse<ReviewCreateResponse> createReview(@RequestBody ReviewCreateRequest reviewCreateRequest) {
 		return ApiResponse.onSuccess(reviewService.createReview(reviewCreateRequest));
+	}
+
+	@Operation(
+		summary = "특정 활동 리뷰 생성",
+		description = "사용자가 특정 활동에 대한 리뷰 게시판에 게시불을 생성합니다."
+	)
+	@PostMapping("{activityId}")
+	public ApiResponse<ReviewCreateResponse> createActivityReview(
+		@PathVariable(name = "activityId") UUID activityId,
+		@RequestBody ReviewActivityCreateRequest request
+	) {
+		return ApiResponse.onSuccess(reviewService.createActivityReview(activityId, request));
 	}
 
 	@Operation(

--- a/src/main/java/com/trendist/post_service/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/trendist/post_service/domain/review/controller/ReviewController.java
@@ -22,6 +22,7 @@ import com.trendist.post_service.domain.review.dto.response.ReviewDeleteResponse
 import com.trendist.post_service.domain.review.dto.response.ReviewGetAllResponse;
 import com.trendist.post_service.domain.review.dto.response.ReviewGetResponse;
 import com.trendist.post_service.domain.review.dto.response.ReviewLikeResponse;
+import com.trendist.post_service.domain.review.dto.response.ReviewSearchResponse;
 import com.trendist.post_service.domain.review.dto.response.ReviewUpdateResponse;
 import com.trendist.post_service.domain.review.service.ReviewService;
 import com.trendist.post_service.global.response.ApiResponse;
@@ -94,5 +95,17 @@ public class ReviewController {
 	@PostMapping("/{reviewId}/like")
 	public ApiResponse<ReviewLikeResponse> likeReview(@PathVariable(name = "reviewId") UUID reviewId) {
 		return ApiResponse.onSuccess(reviewService.likeReview(reviewId));
+	}
+
+	@Operation(
+		summary = "리뷰 게시판 검색",
+		description = "사용자가 리뷰 게시판에 특정 단어를 입력하여 해당하는 리뷰를 검색합니다"
+	)
+	@GetMapping("/search")
+	public ApiResponse<Page<ReviewSearchResponse>> searchReviews(
+		@RequestParam String keyword,
+		@RequestParam(defaultValue = "0") int page
+	) {
+		return ApiResponse.onSuccess(reviewService.searchReviews(keyword, page));
 	}
 }

--- a/src/main/java/com/trendist/post_service/domain/review/controller/ReviewProfileController.java
+++ b/src/main/java/com/trendist/post_service/domain/review/controller/ReviewProfileController.java
@@ -21,7 +21,7 @@ import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/profile")
+@RequestMapping("/profile/reviews")
 public class ReviewProfileController {
 	private final ReviewProfileService reviewProfileService;
 
@@ -29,7 +29,7 @@ public class ReviewProfileController {
 		summary = "내가 쓴 리뷰 게시판 게시물 조회",
 		description = "현재 로그인한 사용자가 리뷰 게시판에 자신이 생성한 게시물들을 조회합니다.(본인 프로필용)"
 	)
-	@GetMapping("/reviews/mine")
+	@GetMapping("/mine")
 	public ApiResponse<Page<ReviewGetUserResponse>> getMyReviews(@RequestParam(defaultValue = "0") int page) {
 		return ApiResponse.onSuccess(reviewProfileService.getMyReviews(page));
 	}
@@ -38,7 +38,7 @@ public class ReviewProfileController {
 		summary = "특정 사용자가 쓴 리뷰 게시물 조회",
 		description = "특정 사용자가 리뷰 게시판에 본인이 생성한 게시물들을 조회합니다.(특정 사용자 프로필용)"
 	)
-	@GetMapping("/reviews/{userId}")
+	@GetMapping("/{userId}")
 	public ApiResponse<Page<ReviewGetUserResponse>> getUserReviews(
 		@RequestParam(defaultValue = "0") int page,
 		@PathVariable(name = "userId") UUID userId) {
@@ -49,7 +49,7 @@ public class ReviewProfileController {
 		summary = "활동 종류별 자신이 진행한 활동 통계 조회",
 		description = "활동 종류별로 자신이 진행한 활동들이 총 몇개인지 통계를 조회합니다."
 	)
-	@GetMapping("/reviews/mine/type/count")
+	@GetMapping("/mine/type/count")
 	public ApiResponse<List<ReviewGetTypeCountResponse>> countMyReviewsByType() {
 		return ApiResponse.onSuccess(reviewProfileService.countMyReviewsByType());
 	}
@@ -58,7 +58,7 @@ public class ReviewProfileController {
 		summary = "활동 종류별 특정 사용자가 진행한 활동 통계 조회",
 		description = "활동 종류별로 특정 사용자가 진행한 활동들이 총 몇개인지 통계를 조회합니다."
 	)
-	@GetMapping("/reviews/{userId}/type/count")
+	@GetMapping("/{userId}/type/count")
 	public ApiResponse<List<ReviewGetTypeCountResponse>> countUserReviewsByType(
 		@PathVariable(name = "userId") UUID userId) {
 		return ApiResponse.onSuccess(reviewProfileService.countUserReviewsByType(userId));
@@ -68,7 +68,7 @@ public class ReviewProfileController {
 		summary = "키워드별 자신이 진행한 활동 통계 조회",
 		description = "키워드별로 자신이 진행한 활동들이 총 몇개인지 통계를 조회합니다."
 	)
-	@GetMapping("/reviews/mine/keyword/count")
+	@GetMapping("/mine/keyword/count")
 	public ApiResponse<List<ReviewGetKeywordCountResponse>> countMyReviewsByKeyword() {
 		return ApiResponse.onSuccess(reviewProfileService.countMyReviewsByKeyword());
 	}
@@ -77,7 +77,7 @@ public class ReviewProfileController {
 		summary = "키워드별 특정 사용자가 진행한 활동 통계 조회",
 		description = "키워드별로 특정 사용자가 진행한 활동들이 총 몇개인지 통계를 조회합니다."
 	)
-	@GetMapping("/reviews/{userId}/keyword/count")
+	@GetMapping("/{userId}/keyword/count")
 	public ApiResponse<List<ReviewGetKeywordCountResponse>> countUserReviewsByKeyword(
 		@PathVariable(name = "userId") UUID userId) {
 		return ApiResponse.onSuccess(reviewProfileService.countUserReviewsByKeyword(userId));

--- a/src/main/java/com/trendist/post_service/domain/review/domain/Review.java
+++ b/src/main/java/com/trendist/post_service/domain/review/domain/Review.java
@@ -38,6 +38,9 @@ public class Review extends BaseTimeEntity {
 	@Column(name = "user_id", nullable = false)
 	private UUID userId;
 
+	@Column(name = "activity_id")
+	private UUID activityId;
+
 	@Column(name = "nickname")
 	private String nickname;
 

--- a/src/main/java/com/trendist/post_service/domain/review/domain/ReviewDocument.java
+++ b/src/main/java/com/trendist/post_service/domain/review/domain/ReviewDocument.java
@@ -1,0 +1,42 @@
+package com.trendist.post_service.domain.review.domain;
+
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
+import org.springframework.data.elasticsearch.annotations.InnerField;
+import org.springframework.data.elasticsearch.annotations.MultiField;
+
+import jakarta.persistence.Id;
+import lombok.Builder;
+import lombok.Getter;
+
+@Document(indexName = "mysql-trendist.trendist.reviews")
+@Builder
+@Getter
+public class ReviewDocument {
+	@Id
+	private String id;
+
+	@MultiField(
+		mainField = @Field(name = "review_title", type = FieldType.Text, analyzer = "standard"),
+		otherFields = {
+			@InnerField(suffix = "keyword", type = FieldType.Keyword)
+		}
+	)
+	private String title;
+
+	@Field(name = "review_content", type = FieldType.Keyword)
+	private String content;
+
+	@Field(name = "review_keyword", type = FieldType.Keyword)
+	private String keyword;
+
+	@Field(name = "nickname", type = FieldType.Keyword)
+	private String nickname;
+
+	@Field(name = "review_like_count", type = FieldType.Integer)
+	private Integer likeCount;
+
+	@Field(name = "created_at", type = FieldType.Keyword)
+	private String createdAt;
+}

--- a/src/main/java/com/trendist/post_service/domain/review/domain/ReviewImageDocument.java
+++ b/src/main/java/com/trendist/post_service/domain/review/domain/ReviewImageDocument.java
@@ -1,0 +1,23 @@
+package com.trendist.post_service.domain.review.domain;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Document(indexName = "mysql-trendist.trendist.review_image_urls")
+@Builder
+@Getter
+public class ReviewImageDocument {
+	@Id
+	private String id;
+
+	@Field(name = "review_id", type = FieldType.Keyword)
+	private String reviewId;
+
+	@Field(name = "image_urls", type = FieldType.Keyword)
+	private String imageUrls;
+}

--- a/src/main/java/com/trendist/post_service/domain/review/dto/request/ReviewActivityCreateRequest.java
+++ b/src/main/java/com/trendist/post_service/domain/review/dto/request/ReviewActivityCreateRequest.java
@@ -1,0 +1,14 @@
+package com.trendist.post_service.domain.review.dto.request;
+
+import java.util.List;
+
+import com.trendist.post_service.domain.review.domain.ActivityPeriod;
+
+public record ReviewActivityCreateRequest(
+	String title,
+	ActivityPeriod activityPeriod,
+	String content,
+	String awardImageUrl,
+	List<String> imageUrls
+) {
+}

--- a/src/main/java/com/trendist/post_service/domain/review/dto/response/ReviewCreateResponse.java
+++ b/src/main/java/com/trendist/post_service/domain/review/dto/response/ReviewCreateResponse.java
@@ -14,6 +14,7 @@ import lombok.Builder;
 @Builder
 public record ReviewCreateResponse(
 	UUID id,
+	UUID activityId,
 	String title,
 	UUID userId,
 	String nickname,
@@ -30,6 +31,7 @@ public record ReviewCreateResponse(
 	public static ReviewCreateResponse from(Review review) {
 		return ReviewCreateResponse.builder()
 			.id(review.getId())
+			.activityId(review.getActivityId())
 			.title(review.getTitle())
 			.userId(review.getUserId())
 			.nickname(review.getNickname())

--- a/src/main/java/com/trendist/post_service/domain/review/dto/response/ReviewSearchResponse.java
+++ b/src/main/java/com/trendist/post_service/domain/review/dto/response/ReviewSearchResponse.java
@@ -1,0 +1,39 @@
+package com.trendist.post_service.domain.review.dto.response;
+
+import java.nio.ByteBuffer;
+import java.util.Base64;
+import java.util.List;
+import java.util.UUID;
+
+import com.trendist.post_service.domain.review.domain.ReviewDocument;
+
+import lombok.Builder;
+
+@Builder
+public record ReviewSearchResponse(
+	UUID id,
+	String title,
+	String content,
+	String keyword,
+	String nickname,
+	Integer likeCount,
+	String createdAt,
+	List<String> reviewImageUrls
+) {
+	public static ReviewSearchResponse of(ReviewDocument reviewDocument, List<String> reviewImageUrls) {
+		byte[] bytes = Base64.getDecoder().decode(reviewDocument.getId());
+		ByteBuffer bb = ByteBuffer.wrap(bytes);
+		UUID uuid = new UUID(bb.getLong(), bb.getLong());
+
+		return ReviewSearchResponse.builder()
+			.id(uuid)
+			.title(reviewDocument.getTitle())
+			.content(reviewDocument.getContent())
+			.keyword(reviewDocument.getKeyword())
+			.nickname(reviewDocument.getNickname())
+			.likeCount(reviewDocument.getLikeCount())
+			.createdAt(reviewDocument.getCreatedAt())
+			.reviewImageUrls(reviewImageUrls)
+			.build();
+	}
+}

--- a/src/main/java/com/trendist/post_service/domain/review/service/ReviewService.java
+++ b/src/main/java/com/trendist/post_service/domain/review/service/ReviewService.java
@@ -1,17 +1,28 @@
 package com.trendist.post_service.domain.review.service;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.elasticsearch.client.elc.NativeQuery;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.SearchHit;
+import org.springframework.data.elasticsearch.core.SearchHits;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.trendist.post_service.domain.review.domain.ActivityType;
 import com.trendist.post_service.domain.review.domain.Keyword;
 import com.trendist.post_service.domain.review.domain.Review;
+import com.trendist.post_service.domain.review.domain.ReviewDocument;
+import com.trendist.post_service.domain.review.domain.ReviewImageDocument;
 import com.trendist.post_service.domain.review.domain.ReviewLike;
 import com.trendist.post_service.domain.review.domain.ReviewSort;
 import com.trendist.post_service.domain.review.dto.request.ReviewCreateRequest;
@@ -21,6 +32,7 @@ import com.trendist.post_service.domain.review.dto.response.ReviewDeleteResponse
 import com.trendist.post_service.domain.review.dto.response.ReviewGetAllResponse;
 import com.trendist.post_service.domain.review.dto.response.ReviewGetResponse;
 import com.trendist.post_service.domain.review.dto.response.ReviewLikeResponse;
+import com.trendist.post_service.domain.review.dto.response.ReviewSearchResponse;
 import com.trendist.post_service.domain.review.dto.response.ReviewUpdateResponse;
 import com.trendist.post_service.domain.review.repository.ReviewLikeRepository;
 import com.trendist.post_service.domain.review.repository.ReviewRepository;
@@ -28,6 +40,9 @@ import com.trendist.post_service.global.exception.ApiException;
 import com.trendist.post_service.global.feign.user.client.UserServiceClient;
 import com.trendist.post_service.global.response.status.ErrorStatus;
 
+import co.elastic.clients.elasticsearch._types.FieldValue;
+import co.elastic.clients.elasticsearch._types.SortOrder;
+import co.elastic.clients.elasticsearch._types.query_dsl.TermsQueryField;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -36,6 +51,7 @@ public class ReviewService {
 	private final ReviewRepository reviewRepository;
 	private final ReviewLikeRepository reviewLikeRepository;
 	private final UserServiceClient userServiceClient;
+	private final ElasticsearchOperations esOps;
 
 	@Transactional
 	public ReviewCreateResponse createReview(ReviewCreateRequest reviewCreateRequest) {
@@ -168,5 +184,64 @@ public class ReviewService {
 		}
 
 		return ReviewLikeResponse.of(reviewLike, like);
+	}
+
+	public Page<ReviewSearchResponse> searchReviews(String keyword, int page) {
+		Pageable pageable = PageRequest.of(page, 9);
+
+		NativeQuery reviewQuery = NativeQuery.builder()
+			.withQuery(q -> q
+				.wildcard(w -> w
+					.field("review_title.keyword")
+					.value("*" + keyword + "*")
+				)
+			)
+			.withSort(s -> s
+				.field(f -> f
+					.field("created_at.keyword")
+					.order(SortOrder.Desc)
+				)
+			)
+			.withPageable(pageable)
+			.build();
+
+		SearchHits<ReviewDocument> reviewHits = esOps.search(reviewQuery, ReviewDocument.class);
+		List<String> reviewIds = reviewHits.getSearchHits().stream()
+			.map(hit -> hit.getContent().getId())
+			.toList();
+
+		List<FieldValue> idValues = reviewIds.stream()
+			.map(FieldValue::of)
+			.toList();
+
+		// 4) review_image_urls 인덱스에서 review_id 필드로 terms 쿼리
+		NativeQuery imageQuery = NativeQuery.builder()
+			.withQuery(q -> q.terms(t -> t
+				.field("review_id.keyword")
+				.terms(
+					TermsQueryField.of(b -> b.value(idValues))
+				)
+			))
+			.withPageable(Pageable.unpaged())
+			.build();
+
+		SearchHits<ReviewImageDocument> imageHits = esOps.search(imageQuery, ReviewImageDocument.class);
+
+		Map<String, List<String>> imageMap = imageHits.getSearchHits().stream()
+			.map(SearchHit::getContent)
+			.collect(Collectors.groupingBy(
+				ReviewImageDocument::getReviewId,
+				Collectors.mapping(ReviewImageDocument::getImageUrls, Collectors.toList())
+			));
+
+		List<ReviewSearchResponse> content = reviewHits.getSearchHits().stream()
+			.map(hit -> {
+				ReviewDocument doc = hit.getContent();
+				List<String> urls = imageMap.getOrDefault(doc.getId(), Collections.emptyList());
+				return ReviewSearchResponse.of(doc, urls);
+			})
+			.toList();
+
+		return new PageImpl<>(content, pageable, reviewHits.getTotalHits());
 	}
 }

--- a/src/main/java/com/trendist/post_service/domain/s3/controller/PresignedUrlController.java
+++ b/src/main/java/com/trendist/post_service/domain/s3/controller/PresignedUrlController.java
@@ -5,9 +5,11 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.trendist.post_service.global.response.ApiResponse;
 import com.trendist.post_service.domain.s3.dto.request.PresignedUrlRequest;
 import com.trendist.post_service.domain.s3.dto.response.PresignedUrlResponse;
+import com.trendist.post_service.global.response.ApiResponse;
+import com.trendist.post_service.domain.s3.dto.request.PresignedUrlsRequest;
+import com.trendist.post_service.domain.s3.dto.response.PresignedUrlsResponse;
 import com.trendist.post_service.domain.s3.service.PresignedUrlService;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -15,16 +17,25 @@ import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/posts")
+@RequestMapping("/presignedurls")
 public class PresignedUrlController {
 	private final PresignedUrlService presignedUrlService;
+
+	@Operation(
+		summary = "PresignedUrl 여러개 발급",
+		description = "s3 버킷에 이미지를 업로드하기 위한 PresignedUrl을 여러개 발급합니다."
+	)
+	@PostMapping("/images")
+	public ApiResponse<PresignedUrlsResponse> getPresignedUrls(@RequestBody PresignedUrlsRequest presignedUrlsRequest) {
+		return ApiResponse.onSuccess(presignedUrlService.getPreSignedUrls(presignedUrlsRequest.imageNames()));
+	}
 
 	@Operation(
 		summary = "PresignedUrl 발급",
 		description = "s3 버킷에 이미지를 업로드하기 위한 PresignedUrl을 발급합니다."
 	)
-	@PostMapping("/presignedurls")
+	@PostMapping("/image")
 	public ApiResponse<PresignedUrlResponse> getPresignedUrl(@RequestBody PresignedUrlRequest presignedUrlRequest) {
-		return ApiResponse.onSuccess(presignedUrlService.getPreSignedUrl(presignedUrlRequest.imageNames()));
+		return ApiResponse.onSuccess(presignedUrlService.getPreSignedUrl(presignedUrlRequest.imageName()));
 	}
 }

--- a/src/main/java/com/trendist/post_service/domain/s3/dto/request/PresignedUrlRequest.java
+++ b/src/main/java/com/trendist/post_service/domain/s3/dto/request/PresignedUrlRequest.java
@@ -1,8 +1,6 @@
 package com.trendist.post_service.domain.s3.dto.request;
 
-import java.util.List;
-
 public record PresignedUrlRequest(
-	List<String> imageNames
+	String imageName
 ) {
 }

--- a/src/main/java/com/trendist/post_service/domain/s3/dto/request/PresignedUrlsRequest.java
+++ b/src/main/java/com/trendist/post_service/domain/s3/dto/request/PresignedUrlsRequest.java
@@ -1,0 +1,8 @@
+package com.trendist.post_service.domain.s3.dto.request;
+
+import java.util.List;
+
+public record PresignedUrlsRequest(
+	List<String> imageNames
+) {
+}

--- a/src/main/java/com/trendist/post_service/domain/s3/dto/response/PresignedUrlResponse.java
+++ b/src/main/java/com/trendist/post_service/domain/s3/dto/response/PresignedUrlResponse.java
@@ -1,16 +1,14 @@
 package com.trendist.post_service.domain.s3.dto.response;
 
-import java.util.List;
-
 import lombok.Builder;
 
 @Builder
 public record PresignedUrlResponse(
-	List<String> PresignedUrls
+	String presignedUrl
 ) {
-	public static PresignedUrlResponse from(List<String> urls) {
+	public static PresignedUrlResponse from(String url) {
 		return PresignedUrlResponse.builder()
-			.PresignedUrls(urls)
+			.presignedUrl(url)
 			.build();
 	}
 }

--- a/src/main/java/com/trendist/post_service/domain/s3/dto/response/PresignedUrlsResponse.java
+++ b/src/main/java/com/trendist/post_service/domain/s3/dto/response/PresignedUrlsResponse.java
@@ -1,0 +1,16 @@
+package com.trendist.post_service.domain.s3.dto.response;
+
+import java.util.List;
+
+import lombok.Builder;
+
+@Builder
+public record PresignedUrlsResponse(
+	List<String> PresignedUrls
+) {
+	public static PresignedUrlsResponse from(List<String> urls) {
+		return PresignedUrlsResponse.builder()
+			.PresignedUrls(urls)
+			.build();
+	}
+}

--- a/src/main/java/com/trendist/post_service/domain/s3/service/PresignedUrlService.java
+++ b/src/main/java/com/trendist/post_service/domain/s3/service/PresignedUrlService.java
@@ -12,9 +12,10 @@ import org.springframework.transaction.annotation.Transactional;
 import com.amazonaws.HttpMethod;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
+import com.trendist.post_service.domain.s3.dto.response.PresignedUrlResponse;
 import com.trendist.post_service.global.exception.ApiException;
 import com.trendist.post_service.global.response.status.ErrorStatus;
-import com.trendist.post_service.domain.s3.dto.response.PresignedUrlResponse;
+import com.trendist.post_service.domain.s3.dto.response.PresignedUrlsResponse;
 
 import lombok.RequiredArgsConstructor;
 
@@ -32,7 +33,7 @@ public class PresignedUrlService {
 	private static final int MAX_FILES_COUNT = 5;
 
 	@Transactional
-	public PresignedUrlResponse getPreSignedUrl(List<String> originalFilenames) {
+	public PresignedUrlsResponse getPreSignedUrls(List<String> originalFilenames) {
 		if (originalFilenames.size() > MAX_FILES_COUNT) {
 			throw new ApiException(ErrorStatus._S3_OVER_MAX_FILES);
 		}
@@ -46,7 +47,16 @@ public class PresignedUrlService {
 			})
 			.toList();
 
-		return PresignedUrlResponse.from(urls);
+		return PresignedUrlsResponse.from(urls);
+	}
+
+	@Transactional
+	public PresignedUrlResponse getPreSignedUrl(String originalFilename) {
+		String path = createPath(originalFilename);
+		GeneratePresignedUrlRequest request = getGeneratePreSignedUrlRequest(bucketName, path);
+		URL prsignedUrl = amazonS3.generatePresignedUrl(request);
+
+		return PresignedUrlResponse.from(prsignedUrl.toString());
 	}
 
 	private GeneratePresignedUrlRequest getGeneratePreSignedUrlRequest(String bucket, String fileName) {

--- a/src/main/java/com/trendist/post_service/domain/s3/service/PresignedUrlService.java
+++ b/src/main/java/com/trendist/post_service/domain/s3/service/PresignedUrlService.java
@@ -39,7 +39,7 @@ public class PresignedUrlService {
 		}
 
 		List<String> urls = originalFilenames.stream()
-			.map(this::createPath)
+			.map(this::createPostPath)
 			.map(path -> {
 				GeneratePresignedUrlRequest request = getGeneratePreSignedUrlRequest(bucketName, path);
 				URL presignedUrl = amazonS3.generatePresignedUrl(request);
@@ -52,7 +52,7 @@ public class PresignedUrlService {
 
 	@Transactional
 	public PresignedUrlResponse getPreSignedUrl(String originalFilename) {
-		String path = createPath(originalFilename);
+		String path = createAwardPath(originalFilename);
 		GeneratePresignedUrlRequest request = getGeneratePreSignedUrlRequest(bucketName, path);
 		URL prsignedUrl = amazonS3.generatePresignedUrl(request);
 
@@ -78,7 +78,14 @@ public class PresignedUrlService {
 		return UUID.randomUUID().toString();
 	}
 
-	private String createPath(String fileName) {
+	private String createPostPath(String fileName) {
+		String prefix = "posts";
+		String fileId = createFileId();
+		return String.format("%s/%s", prefix, fileId + fileName);
+	}
+
+	private String createAwardPath(String fileName) {
+		String prefix = "award";
 		String fileId = createFileId();
 		return String.format("%s/%s", prefix, fileId + fileName);
 	}

--- a/src/main/java/com/trendist/post_service/global/feign/activity/client/ActivityServiceClient.java
+++ b/src/main/java/com/trendist/post_service/global/feign/activity/client/ActivityServiceClient.java
@@ -1,0 +1,18 @@
+package com.trendist.post_service.global.feign.activity.client;
+
+import java.util.UUID;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import com.trendist.post_service.global.feign.activity.dto.ActivityGetResponse;
+import com.trendist.post_service.global.response.ApiResponse;
+
+@FeignClient(name = "activity-service")
+public interface ActivityServiceClient {
+	@GetMapping("/activities/{activityId}")
+	ApiResponse<ActivityGetResponse> getActivity(
+		@PathVariable(name = "activityId") UUID activityId
+	);
+}

--- a/src/main/java/com/trendist/post_service/global/feign/activity/dto/ActivityGetResponse.java
+++ b/src/main/java/com/trendist/post_service/global/feign/activity/dto/ActivityGetResponse.java
@@ -1,0 +1,22 @@
+package com.trendist.post_service.global.feign.activity.dto;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import com.trendist.post_service.domain.review.domain.ActivityType;
+import com.trendist.post_service.domain.review.domain.Keyword;
+
+import lombok.Builder;
+
+@Builder
+public record ActivityGetResponse(
+	UUID id,
+	String name,
+	String siteUrl,
+	Keyword keyword,
+	ActivityType activityType,
+	LocalDateTime startDate,
+	LocalDateTime endDate,
+	String imageUrl
+) {
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,7 +16,7 @@ spring:
             read-timeout: 5000
   datasource:
     url: ${DB_URL}
-    username: root
+    username: admin
     password: ${DB_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -32,6 +32,9 @@ spring:
   sql:
     init:
       mode: always
+  elasticsearch:
+    uris: http://localhost:9200
+    connection-timeout: 1000
 
 server-uri: http://localhost:8081
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -53,4 +53,3 @@ aws:
     secretKey: ${S3_SECRET_KEY}
     bucketName: ${S3_BUCKET}
     region: ap-northeast-2
-    prefix: posts


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [x] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [x] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용
**cdc 아키텍처를 구현하여 검색 기능을 구현하였습니다.**
- source DB: mysql
- target DB: elasticsearch
- connect: kafka(+debezium)

1. 우선 docker-compose 파일 작성하여 이미지를 다운받았습니다. 
- 추가적으로 sink-connector와 관련한 설정을 추가적으로 해주었습니다. 
```shell
services:
  zookeeper:
    image: confluentinc/cp-zookeeper:7.4.0
    container_name: zookeeper
    environment:
      ZOOKEEPER_CLIENT_PORT: 2181

  kafka:
    image: confluentinc/cp-kafka:7.4.0
    container_name: kafka
    depends_on:
      - zookeeper
    ports:
      - "9092:9092"
    environment:
      KAFKA_BROKER_ID: 1
      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1

  connect:
    image: debezium/connect:2.5
    container_name: connect
    depends_on:
      - kafka
    ports:
      - "8083:8083"
    environment:
      BOOTSTRAP_SERVERS: kafka:9092
      GROUP_ID: 1
      CONFIG_STORAGE_TOPIC: connect-configs
      OFFSET_STORAGE_TOPIC: connect-offsets
      STATUS_STORAGE_TOPIC: connect-status
      CONNECT_KEY_CONVERTER: org.apache.kafka.connect.json.JsonConverter
      CONNECT_VALUE_CONVERTER: org.apache.kafka.connect.json.JsonConverter
      CONNECT_REST_ADVERTISED_HOST_NAME: connect
      CONNECT_PLUGIN_PATH: /kafka/connect,/usr/share/java

  elasticsearch:
    image: docker.elastic.co/elasticsearch/elasticsearch:8.12.0
    container_name: elasticsearch
    ports:
      - "9200:9200"
      - "9300:9300"
    environment:
      discovery.type: single-node
      ES_JAVA_OPTS: -Xms16g -Xmx16g
      ingest.geoip.downloader.enabled: false
      xpack.security.enabled: false
      xpack.security.transport.ssl.enabled: false
      xpack.security.http.ssl.enabled: false
      xpack.monitoring.collection.enabled: true
    ulimits:
      memlock:
        soft: -1
        hard: -1

  kibana:
    image: docker.elastic.co/kibana/kibana:8.12.0
    container_name: kibana
    depends_on:
      - elasticsearch
    ports:
      - "5601:5601"
    environment:
      ELASTICSEARCH_HOSTS: "http://elasticsearch:9200"
      XPACK_SECURITY_ENABLED: "false"
``` 
---

2. debezium을 이용한 mysql-source-connector를 등록합니다.
```shell
curl -i -X POST http://localhost:8083/connectors \
  -H "Content-Type: application/json" \
  -d '{
    "name": "mysql-source-connector-trendist",
    "config": {
      "connector.class": "io.debezium.connector.mysql.MySqlConnector",
      "database.hostname": "trendist.cr8iw6co24hb.ap-northeast-2.rds.amazonaws.com",
      "database.port": "3306",
      "database.user": "admin",
      "database.password": "jimking1",
      "database.server.id": "2",
      "topic.prefix": "mysql-trendist",
      "database.server.name": "mysql-trendist",
      "database.include.list": "trendist",
      "table.include.list": "trendist.users,trendist.posts,trendist.reviews,trendist.issues,trendist.activities,trendist.review_image_urls",

      "key.converter": "org.apache.kafka.connect.json.JsonConverter",
      "key.converter.schemas.enable": "false",
      "value.converter": "org.apache.kafka.connect.json.JsonConverter",
      "value.converter.schemas.enable": "false",
      
      "transforms": "unwrap",
      "transforms.unwrap.type": "io.debezium.transforms.ExtractNewRecordState",
      "transforms.unwrap.drop.tombstones": "false",

      "include.schema.changes": "false",
      "tombstones.on.delete": "true",

      "snapshot.mode": "when_needed",
      "schema.history.internal.kafka.bootstrap.servers": "kafka:9092",
      "schema.history.internal.kafka.topic": "debezium-schema-history.user",
      "database.connectionTimeZone": "Asia/Seoul"
    }
  }'
``` 
---

3. elasticsearch-sink-connector를 등록합니다. post-service에서 진행하는 검색 기능은 posts, reviews 두개이기에 posts, reviews, review_image_urls 테이블을 등록합니다. 
```shell
curl -i -X POST http://localhost:8083/connectors \
  -H "Content-Type: application/json" \
  -d '{
  "name": "elasticsearch-sink-connector-posts",
  "config": {
    "connector.class": "io.confluent.connect.elasticsearch.ElasticsearchSinkConnector",
    "tasks.max": "1",
    "topics": "mysql-trendist.trendist.posts",
    "connection.url": "http://elasticsearch:9200",

    "key.converter": "org.apache.kafka.connect.json.JsonConverter",
    "key.converter.schemas.enable": "false",
    "value.converter": "org.apache.kafka.connect.json.JsonConverter",
    "value.converter.schemas.enable": "false",
    
    "transforms": "unwrap,convertCreatedAt,convertUpdatedAt,extractKey",
    
    "transforms.unwrap.type": "io.debezium.transforms.ExtractNewRecordState",
    "transforms.unwrap.drop.tombstones": "false",
    "transforms.unwrap.delete.handling.mode": "rewrite",
    
    "transforms.convertCreatedAt.type": "org.apache.kafka.connect.transforms.TimestampConverter$Value",
    "transforms.convertCreatedAt.field": "created_at",
    "transforms.convertCreatedAt.format": "yyyy-MM-dd HH:mm:ss.SSS",
    "transforms.convertCreatedAt.target.type": "string",
    "transforms.convertCreatedAt.unix.precision": "microseconds",
    
    "transforms.convertUpdatedAt.type": "org.apache.kafka.connect.transforms.TimestampConverter$Value",
    "transforms.convertUpdatedAt.field": "updated_at",
    "transforms.convertUpdatedAt.format": "yyyy-MM-dd HH:mm:ss.SSS",
    "transforms.convertUpdatedAt.target.type": "string",
    "transforms.convertUpdatedAt.unix.precision": "microseconds",
    
    "transforms.extractKey.type": "org.apache.kafka.connect.transforms.ExtractField$Key",
    "transforms.extractKey.field": "post_id",
    
    "consumer.override.auto.offset.reset": "earliest",

    "write.method": "upsert",
    "behavior.on.null.values": "delete",
    "key.ignore": "false",
    "schema.ignore": "true",
    "errors.tolerance": "none"
  }
}'
```
```shell
curl -i -X POST http://localhost:8083/connectors \
  -H "Content-Type: application/json" \
  -d '{
  "name": "elasticsearch-sink-connector-reviews",
  "config": {
    "connector.class": "io.confluent.connect.elasticsearch.ElasticsearchSinkConnector",
    "tasks.max": "1",
    "topics": "mysql-trendist.trendist.reviews",
    "connection.url": "http://elasticsearch:9200",

    "key.converter": "org.apache.kafka.connect.json.JsonConverter",
    "key.converter.schemas.enable": "false",
    "value.converter": "org.apache.kafka.connect.json.JsonConverter",
    "value.converter.schemas.enable": "false",

    "transforms": "convertCreatedAt,convertUpdatedAt,unwrap,extractKey",
    
    "transforms.convertCreatedAt.type": "org.apache.kafka.connect.transforms.TimestampConverter$Value",
    "transforms.convertCreatedAt.field": "created_at",
    "transforms.convertCreatedAt.format": "yyyy-MM-dd HH:mm:ss.SSS",
    "transforms.convertCreatedAt.target.type": "string",
    "transforms.convertCreatedAt.unix.precision": "microseconds",
    
    "transforms.convertUpdatedAt.type": "org.apache.kafka.connect.transforms.TimestampConverter$Value",
    "transforms.convertUpdatedAt.field": "updated_at",
    "transforms.convertUpdatedAt.format": "yyyy-MM-dd HH:mm:ss.SSS",
    "transforms.convertUpdatedAt.target.type": "string",
    "transforms.convertUpdatedAt.unix.precision": "microseconds",
    
    "transforms.unwrap.type": "io.debezium.transforms.ExtractNewRecordState",
    "transforms.unwrap.drop.tombstones": "false",
    "transforms.unwrap.delete.handling.mode": "rewrite",
    
    "transforms.extractKey.type": "org.apache.kafka.connect.transforms.ExtractField$Key",
    "transforms.extractKey.field": "review_id",

    "write.method": "upsert",
    "behavior.on.null.values": "delete",
    "key.ignore": "false",
    "schema.ignore": "true",
    "errors.tolerance": "none"
  }
}'
```   
```shell
curl -i -X POST http://localhost:8083/connectors \
  -H "Content-Type: application/json" \
  -d '{
  "name": "elasticsearch-sink-connector-review_image_urls",
  "config": {
    "connector.class": "io.confluent.connect.elasticsearch.ElasticsearchSinkConnector",
    "tasks.max": "1",
    "topics": "mysql-trendist.trendist.review_image_urls",
    "connection.url": "http://elasticsearch:9200",

    "key.converter": "org.apache.kafka.connect.json.JsonConverter",
    "key.converter.schemas.enable": "false",
    "value.converter": "org.apache.kafka.connect.json.JsonConverter",
    "value.converter.schemas.enable": "false",

    "transforms": "unwrap,makeKey,extractKey",
    
    "transforms.unwrap.type": "io.debezium.transforms.ExtractNewRecordState",
    "transforms.unwrap.drop.tombstones": "false",
    "transforms.unwrap.delete.handling.mode": "rewrite",
    
    "transforms.makeKey.type": "org.apache.kafka.connect.transforms.ValueToKey",
    "transforms.makeKey.fields": "review_id",
    
    "transforms.extractKey.type": "org.apache.kafka.connect.transforms.ExtractField$Key",
    "transforms.extractKey.field": "review_id",

    "write.method": "upsert",
    "behavior.on.null.values": "delete",
    "key.ignore": "true",
    "schema.ignore": "true",
    "errors.tolerance": "none"
  }
}'
``` 
---

4. 등록이 잘 되었는지, 커넥터 등록이 잘 되었는지  확인하였습니다.
<img width="1056" alt="image" src="https://github.com/user-attachments/assets/85ed88b5-3a08-4d74-bcbd-57ce89a93489" />
<img width="585" alt="image" src="https://github.com/user-attachments/assets/c7e84190-99c0-4a5d-967a-126bbc0a6546" />

---

**이를 통해 자유 게시물 검색 기능을 구현하였습니다.**
![image](https://github.com/user-attachments/assets/aeac7e56-576f-48a8-bac9-29504d4e21cc)
---

**리뷰 게시물 리뷰 검색 기능을 구현하였습니다.**
![image](https://github.com/user-attachments/assets/021c4c70-bcaa-4a4b-8940-2692a943c287)

---

## 🔗 관련 이슈
- close #17 

---

## 💡 추가 사항
- 현재는 로컬 환경에서 구현을 진행하였습니다. 해당 설정들은 서버와 연결이 되면 설정을 동일하게 진행해야합니다.

**추가적으로 리뷰 생성의 경우 특정 활동에 대한 리뷰도 작성할 수 있도록 구현하였습니다.**
