### PR TITLE
refactor: imgOcrResult null값 처리 가능하게 수정

### DIFF
--- a/src/main/java/com/trendist/post_service/domain/review/controller/ReviewProfileController.java
+++ b/src/main/java/com/trendist/post_service/domain/review/controller/ReviewProfileController.java
@@ -94,8 +94,8 @@ public class ReviewProfileController {
 	}
 
 	@Operation(
-		summary = "월별 자신이 진행한 활동 수 조회",
-		description = "월별로 자신이 진행한 활동 수가 몇개인지 통계를 조회합니다."
+		summary = "월별 특정 사용자가 진행한 활동 수 조회",
+		description = "월별로 특정 사용자가 진행한 활동 수가 몇개인지 통계를 조회합니다."
 	)
 	@GetMapping("/{userId}/month/count")
 	public ApiResponse<List<ReviewMonthlyCountResponse>> countUserReviewsByMonth(

--- a/src/main/java/com/trendist/post_service/domain/review/domain/Review.java
+++ b/src/main/java/com/trendist/post_service/domain/review/domain/Review.java
@@ -86,8 +86,7 @@ public class Review extends BaseTimeEntity {
 	private Integer likeCount = 0;
 
 	@Column(name = "award_ocr_result")
-	@Builder.Default
-	private Boolean awardOcrResult = false;
+	private Boolean awardOcrResult;
 
 	@Column(name = "ocr_result")
 	@Builder.Default

--- a/src/main/java/com/trendist/post_service/domain/review/service/ExpScheduler.java
+++ b/src/main/java/com/trendist/post_service/domain/review/service/ExpScheduler.java
@@ -53,9 +53,10 @@ public class ExpScheduler {
 			return 0;
 		}
 		//공모전 로직
+		//awardOcrResult 가 Boolean TRUE 인 경우만 won=true
 		if (review.getActivityType() == ActivityType.CONTEST) {
 			int state = review.getIsExpGiven();
-			boolean won = review.getAwardOcrResult();
+			boolean won = Boolean.TRUE.equals(review.getAwardOcrResult());
 
 			if (state == 0) {
 				//공모전은 awardOcrResult에 따라 300 / 100점 지급


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용

사용자가 awardImg를 첨부하지 않을 경우, awardOcrResult값을 null값으로 지정하도록 수정하였습니다.
exp 지급 스케줄러에서도 문제없이 동작하도록 수정하였습니다.

![스크린샷 2025-06-08 153000](https://github.com/user-attachments/assets/4c8aaaac-8b4f-474d-aedd-6c6365a8e3ea)
![스크린샷 2025-06-08 153107](https://github.com/user-attachments/assets/38fc6c2b-801a-4422-b286-2d0d31747b64)

---

## 🔗 관련 이슈
- close #39 

---

## 💡 추가 사항

